### PR TITLE
fix(chart): normalize kline timestamps and tune TF limits

### DIFF
--- a/apps/web/menu/cosmos/chart.html
+++ b/apps/web/menu/cosmos/chart.html
@@ -104,7 +104,14 @@ async function getJson(direct, proxy){
   try{ const r=await fetch(direct); if(!r.ok) throw 0; return await r.json(); }
   catch{ const r2=await fetch(proxy); if(!r2.ok) throw new Error('fetch failed'); return await r2.json(); }
 }
-function klineURL(sym,tf,limit=850){
+function tfLimit(tf){
+  if (tf.endsWith('m')) return 1200;     // 1m/5m/15m/30m
+  if (tf==='1h' || tf==='4h') return 1500;
+  if (tf==='1d' || tf==='1w') return 1000;
+  return 1000;
+}
+function klineURL(sym,tf,limit){
+  limit = limit ?? tfLimit(tf);
   const q=`symbol=${sym}&interval=${tf}&limit=${limit}`;
   return [
     `https://api.binance.com/api/v3/klines?${q}`,
@@ -265,8 +272,9 @@ document.getElementById('btnReset').onclick = ()=> { chart.timeScale().setVisibl
 let rtime=[], klines=[];
 
 /* 변환기 */
-const toCandle = k => ({ time:Math.floor(k[0]/1000), open:+k[1], high:+k[2], low:+k[3], close:+k[4] });
-const toVolume = k => ({ time:Math.floor(k[0]/1000), value:+k[5], color:(+k[4] >= +k[1]) ? 'rgba(34,197,94,.55)' : 'rgba(239,68,68,.55)' });
+function normTs(t){ return t > 1e12 ? Math.floor(t/1000) : t; }
+const toCandle = k => ({ time: normTs(k[0]), open:+k[1], high:+k[2], low:+k[3], close:+k[4] });
+const toVolume = k => ({ time: normTs(k[0]), value:+k[5], color:(+k[4] >= +k[1]) ? 'rgba(34,197,94,.55)' : 'rgba(239,68,68,.55)' });
 
 /* 로더 */
 async function loadAll(){
@@ -274,7 +282,7 @@ async function loadAll(){
   const [dURL,pURL] = klineURL(SYMBOL, TF);
   const rows = await getJson(dURL,pURL);
   klines = rows;
-  rtime = rows.map(r=>Math.floor(r[0]/1000));
+  rtime = rows.map(r=>normTs(r[0]));
 
   const candles = rows.map(toCandle);
   const volumes = rows.map(toVolume);


### PR DESCRIPTION
## Summary
- add timestamp normalization guard and apply to candle and volume mappers
- tune TF-specific limits for kline requests to avoid gaps

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5363817bc832f8f6420276021eb16