### PR TITLE
Fix chart gaps and restore Binance sparkline

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1135,14 +1135,14 @@
     let chartCanvas=null, chartContext=null, currentData=new Map();
     
     const cryptoConfig=[
-      {id:'bitcoin',symbol:'BTCUSDT',name:'BTC',color:'#ff9500',visible:true,basePrice:112154},
-      {id:'ethereum',symbol:'ETHUSDT',name:'ETH',color:'#627eea',visible:true,basePrice:3680},
-      {id:'binancecoin',symbol:'BNBUSDT',name:'BNB',color:'#f0b90b',visible:true,basePrice:715},
-      {id:'solana',symbol:'SOLUSDT',name:'SOL',color:'#9945ff',visible:true,basePrice:185},
-      {id:'cardano',symbol:'ADAUSDT',name:'ADA',color:'#0066cc',visible:true,basePrice:1.12},
-      {id:'ripple',symbol:'XRPUSDT',name:'XRP',color:'#00d4aa',visible:true,basePrice:5.124},
-      {id:'avalanche-2',symbol:'AVAXUSDT',name:'AVAX',color:'#e84142',visible:true,basePrice:52},
-      {id:'dogecoin',symbol:'DOGEUSDT',name:'DOGE',color:'#c2a633',visible:true,basePrice:.384}
+      {id:'BTC',name:'BTC',color:'#ff9500',visible:true},
+      {id:'ETH',name:'ETH',color:'#627eea',visible:true},
+      {id:'BNB',name:'BNB',color:'#f0b90b',visible:true},
+      {id:'SOL',name:'SOL',color:'#9945ff',visible:true},
+      {id:'ADA',name:'ADA',color:'#0066cc',visible:true},
+      {id:'XRP',name:'XRP',color:'#00d4aa',visible:true},
+      {id:'AVAX',name:'AVAX',color:'#e84142',visible:true},
+      {id:'DOGE',name:'DOGE',color:'#c2a633',visible:true}
     ];
 
      async function initCosmosChart(){
@@ -1187,24 +1187,21 @@
     }
     
  async function fetchAllCosmosData(){
-      const promises=cryptoConfig.map(c=>fetchCoinHistory(c));
-      await Promise.all(promises);
-      drawChart();
-    }
-
-    async function fetchCoinHistory(crypto){
       try{
-        const days=Number(document.getElementById('timeSelector')?.value||'7');
-        const interval=days<=1?'1h':'1d';
-        const limit=days<=1?24*days:days;
-        const res=await fetch(`/api/binance/klines?symbol=${crypto.symbol}&interval=${interval}&limit=${limit}`);
-        const json=await res.json();
-        const data=json.map(k=>({timestamp:k.timestamp??k[0],price:k.price??k[4]}));
-        currentData.set(crypto.id,data);
+        const rows = await fetch('/api/binance/markets?per_page=50&heavy_n=50').then(r=>r.json());
+        currentData.clear();
+        cryptoConfig.forEach(c=>{
+          const r = rows.find(x=>x.name===c.name || x.symbol?.toUpperCase()===c.name);
+          if(!r) return;
+          const base = r.sparkline_in_7d?.price?.[0] ?? 1;
+          const pts = (r.sparkline_in_7d?.price || []).map((v,i)=>({timestamp:i, price:(v/base - 1)*100}));
+          currentData.set(c.id, pts);
+        });
+        drawChart();
       }catch(err){
-        console.error('fetchCoinHistory',crypto.id,err);
+        console.error('fetchAllCosmosData', err);
       }
-       }
+    }
     
     let raf=0;
     function startChartAnimation(){
@@ -1307,32 +1304,12 @@
       ctx.fillStyle=crypto.color; 
       ctx.font='11px Orbitron, monospace'; 
       ctx.textAlign='left';
-      ctx.fillText(`${last.price.toFixed(crypto.basePrice<1?4:0)}`, lx+8, ly+3);
+      ctx.fillText(`${last.price.toFixed(2)}%`, lx+8, ly+3);
       
       ctx.shadowBlur=0; 
       ctx.textAlign='start';
     }
     
-    async function updateCosmosData(){
-      try{
-        const ids=cryptoConfig.map(c=>c.id).join(',');
-        const res=await fetch(`/api/simple/price?ids=${ids}&vs_currencies=usd`);
-        const prices=await res.json();
-        const now=Date.now();
-    cryptoConfig.forEach(c=>{
-          const price=prices[c.id]?.usd;
-          if(price===undefined) return;
-          const d=currentData.get(c.id)||[];
-          d.push({timestamp:now,price});
-          if(d.length>120) d.shift();
-          currentData.set(c.id,d);
-        });
-        drawChart();
-      }catch(err){
-        console.error('updateCosmosData',err);
-      }
-    }
-
     async function fetchMarketCap(){
       try{
         const res=await fetch('/api/global');
@@ -1345,7 +1322,7 @@
     }
 
     function startRealTimeUpdates(){
-      setInterval(updateCosmosData,10000);
+      setInterval(fetchAllCosmosData,10000);
       setInterval(fetchMarketCap,60000);
     }
 

--- a/apps/web/menu/cosmos/chart.html
+++ b/apps/web/menu/cosmos/chart.html
@@ -296,9 +296,8 @@ async function loadAll(){
   rows.sort((a,b)=> Number(a[0]) - Number(b[0]));
 
   // ms → s (초)로 통일
-  const msInput = Array.isArray(rows?.[0]) && Number(rows[0][0]) > 1e12; // 13자리면 ms
-  if (msInput) {
-    for (let i=0;i<rows.length;i++) rows[i][0] = Math.round(Number(rows[i][0]) / 1000);
+  if (Number(rows[0][0]) > 1e12) {                 // 13자리면 ms
+    for (let i=0;i<rows.length;i++) rows[i][0] = Math.floor(Number(rows[i][0]) / 1000);
   }
 
   const candles = rows.map(toCandle);


### PR DESCRIPTION
## Summary
- Normalize kline timestamps once and drop redundant /1000 conversions in COSMOS chart
- Drive homepage multi-line spark chart from `/api/binance/markets` with relative percent series

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5649cf9b4832f8a197f1f3bfe7d20