### PR TITLE
feat: switch multi-chart data to binance

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -460,15 +460,21 @@
       background:rgba(139,92,246,.2);
       transform:translateY(-2px) 
     }
-    .legend-color{ 
-      width:12px; 
-      height:3px; 
-      border-radius:2px 
+    .legend-color{
+      width:12px;
+      height:3px;
+      border-radius:2px
     }
-    .price-display{ 
-      color:#8b5cf6; 
-      font-weight:700; 
-      font-size:16px; 
+    .live-price{
+      margin-left:4px;
+      font-family:'Orbitron',monospace;
+      font-size:11px;
+      color:#8b5cf6;
+    }
+    .price-display{
+      color:#8b5cf6;
+      font-weight:700;
+      font-size:16px;
       font-family:'Orbitron',monospace;
       text-shadow:0 0 10px rgba(139,92,246,.5);
     }
@@ -1172,23 +1178,24 @@
     function createChartLegend(){
       const legend=document.getElementById('chartLegend');
       legend.innerHTML='';
-      
+
       cryptoConfig.forEach((c,idx)=>{
         const item=document.createElement('div');
         item.className='legend-item';
-        item.innerHTML=`<div class="legend-color" style="background-color:${c.color}"></div><span>${c.name}</span>`;
-        item.addEventListener('click',()=>{ 
-          c.visible=!c.visible; 
-          item.style.opacity=c.visible?'1':'.35'; 
-          drawChart() 
+        item.innerHTML=`<div class="legend-color" style="background-color:${c.color}"></div><span>${c.name}</span> <span class="live-price" id="price-${c.id}"></span>`;
+        item.addEventListener('click',()=>{
+          c.visible=!c.visible;
+          item.style.opacity=c.visible?'1':'.35';
+          drawChart()
         });
         legend.appendChild(item);
       });
     }
-    
+
  async function fetchAllCosmosData(){
       try{
-        const rows = await fetch('/api/binance/markets?per_page=50&heavy_n=50').then(r=>r.json());
+        const url = `/api/binance/markets?per_page=100&page=1&heavy_n=30`;
+        const rows = await fetch(url).then(r=>r.json());
         currentData.clear();
         cryptoConfig.forEach(c=>{
           const r = rows.find(x=>x.name===c.name || x.symbol?.toUpperCase()===c.name);
@@ -1322,8 +1329,22 @@
     }
 
     function startRealTimeUpdates(){
-      setInterval(fetchAllCosmosData,10000);
       setInterval(fetchMarketCap,60000);
+      (async function loop(){
+        for(const c of cryptoConfig){
+          const bnSym=`${c.id.toUpperCase()}USDT`;
+          try{
+            const r=await fetch(`/api/binance/price?symbol=${bnSym}`).then(r=>r.json());
+            const live=Number(r.price);
+            const el=document.getElementById(`price-${c.id}`);
+            if(el&&!Number.isNaN(live)) el.textContent=`$${live.toFixed(2)}`;
+          }catch(e){
+            console.error('livePrice', bnSym, e);
+          }
+          await new Promise(res=>setTimeout(res,1000));
+        }
+        loop();
+      })();
     }
 
     // 초기화


### PR DESCRIPTION
## Summary
- use Binance markets endpoint for multi-chart data
- poll Binance price endpoint sequentially for live updates

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c56d5a16ec832f9f156d19a9de69fe