### PR TITLE
Adjust enter-to-send behavior for chat

### DIFF
--- a/apps/web/ai/seed.js
+++ b/apps/web/ai/seed.js
@@ -235,7 +235,28 @@ ${personaBlock}`;
 
   // ---------- events ----------
   sendButton.addEventListener('click', sendMessage);
-  // 엔터키 자동전송 제거 - 이제 엔터는 줄바꿈만 가능
+
+  function canSubmitWithEnter(){
+    const landscape = window.innerWidth > window.innerHeight;
+    let pointerFine = true;
+    if (window.matchMedia) {
+      try {
+        pointerFine = window.matchMedia('(pointer: fine)').matches;
+      } catch (_) {
+        pointerFine = true;
+      }
+    }
+    return landscape && pointerFine;
+  }
+
+  messageInput.addEventListener('keydown', (ev)=>{
+    if(ev.key === 'Enter' && !ev.shiftKey){
+      if(!canSubmitWithEnter()) return;
+      ev.preventDefault();
+      sendMessage();
+    }
+  });
+
   messageInput.addEventListener('input', ()=>{
     messageInput.style.height='auto';
     messageInput.style.height = Math.min(messageInput.scrollHeight, window.innerHeight*0.3) + 'px';


### PR DESCRIPTION
## Summary
- allow the chat input to submit on Enter only when the viewport is in landscape mode
- require fine-pointer devices such as desktops/laptops for the enter shortcut so portrait/touch users keep the send button workflow

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c95ff27cbc832fbf97c2ba0bfc6862