### PR TITLE
Enhance Seed chat crypto price handling

### DIFF
--- a/apps/web/ai/seed.js
+++ b/apps/web/ai/seed.js
@@ -100,8 +100,198 @@
 
   // ---------- formatters ----------
   const fmt = {
-    money(v,cur='USD'){ return new Intl.NumberFormat('en-US',{style:'currency',currency:cur}).format(Number(v)); },
-    pct(v){ v=Number(v)||0; const s=(v>0?'+':'')+v.toFixed(2)+'%'; return v>=0?`<b style="color:#60ffa3">${s}</b>`:`<b style="color:#ff6b6b">${s}</b>`;}
+    money(v, cur = 'USD') {
+      const num = Number(v);
+      if (!Number.isFinite(num)) return '--';
+      const safeCur = cur === 'USDT' ? 'USD' : cur;
+      try {
+        return new Intl.NumberFormat('en-US', { style: 'currency', currency: safeCur }).format(num);
+      } catch {
+        return num.toLocaleString('en-US', { maximumFractionDigits: 2 });
+      }
+    },
+    pct(v) {
+      const num = Number(v);
+      if (!Number.isFinite(num)) return '<span style="opacity:.6">--</span>';
+      const s = (num > 0 ? '+' : '') + num.toFixed(2) + '%';
+      return num >= 0
+        ? `<b style="color:#60ffa3">${s}</b>`
+        : `<b style="color:#ff6b6b">${s}</b>`;
+    }
+  };
+
+  const sanitizeKey = (str = '') => str.toLowerCase().replace(/[\s_\-/]/g, '');
+
+  const PRICE_KEYWORD_STRINGS = [
+    '가격', '시세', '얼마', '얼만', '얼마야', '얼만가', '값', '가치',
+    'price', 'cost', 'quote', 'rate', 'how much', '시가', '호가'
+  ];
+
+  const PRICE_KEYWORD_CONFIG = PRICE_KEYWORD_STRINGS.map(str => {
+    const raw = String(str || '').toLowerCase();
+    const normalized = sanitizeKey(raw);
+    return {
+      raw,
+      normalized,
+      tokenParts: raw.split(/\s+/).map(sanitizeKey).filter(Boolean)
+    };
+  });
+
+  const PRICE_KEYWORD_SET = new Set();
+  PRICE_KEYWORD_CONFIG.forEach(({ normalized, tokenParts }) => {
+    if (normalized) PRICE_KEYWORD_SET.add(normalized);
+    tokenParts.forEach(t => PRICE_KEYWORD_SET.add(t));
+  });
+
+  const ASSET_CATALOG = [
+    { symbol: 'BTC', name: 'Bitcoin',   binanceSymbol: 'BTCUSDT', coingeckoId: 'bitcoin',       keywords: ['btc', 'btcusdt', 'bitcoin', '비트', '비트코인', '비트 코인', 'btc/usdt', 'btc-usdt'] },
+    { symbol: 'ETH', name: 'Ethereum',  binanceSymbol: 'ETHUSDT', coingeckoId: 'ethereum',      keywords: ['eth', 'ethusdt', 'ethereum', '이더', '이더리움', '이더 리움', 'eth/usdt', 'eth-usdt'] },
+    { symbol: 'SOL', name: 'Solana',    binanceSymbol: 'SOLUSDT', coingeckoId: 'solana',        keywords: ['sol', 'solusdt', 'solana', '솔라나', 'sol/usdt', 'sol-usdt'] },
+    { symbol: 'XRP', name: 'XRP',       binanceSymbol: 'XRPUSDT', coingeckoId: 'ripple',        keywords: ['xrp', 'xrpusdt', '리플', 'xrp/usdt', 'xrp-usdt'] },
+    { symbol: 'BNB', name: 'BNB',       binanceSymbol: 'BNBUSDT', coingeckoId: 'binancecoin',   keywords: ['bnb', 'bnbusdt', '바이낸스코인', '바이낸스 코인', 'binance coin', 'bnb/usdt', 'bnb-usdt'] },
+    { symbol: 'ADA', name: 'Cardano',   binanceSymbol: 'ADAUSDT', coingeckoId: 'cardano',       keywords: ['ada', 'adausdt', 'cardano', '에이다', '카르다노', 'ada/usdt', 'ada-usdt'] },
+    { symbol: 'DOGE',name: 'Dogecoin',  binanceSymbol: 'DOGEUSDT',coingeckoId: 'dogecoin',      keywords: ['doge', 'dogeusdt', '도지', '도지코인', 'doge/usdt', 'doge-usdt'] },
+    { symbol: 'AVAX',name: 'Avalanche', binanceSymbol: 'AVAXUSDT',coingeckoId: 'avalanche-2',   keywords: ['avax', 'avaxusdt', '아발란체', 'avax/usdt', 'avax-usdt'] },
+    { symbol: 'TRX', name: 'Tron',      binanceSymbol: 'TRXUSDT', coingeckoId: 'tron',          keywords: ['trx', 'trxusdt', '트론', 'trx/usdt', 'trx-usdt'] },
+    { symbol: 'TON', name: 'Toncoin',   binanceSymbol: 'TONUSDT', coingeckoId: 'the-open-network', keywords: ['ton', 'tonusdt', 'toncoin', '톤', '톤코인', 'ton/usdt', 'ton-usdt'] },
+    { symbol: 'MATIC',name: 'Polygon',  binanceSymbol: 'MATICUSDT',coingeckoId: 'matic-network', keywords: ['matic', 'maticusdt', 'polygon', '폴리곤', 'matic/usdt', 'matic-usdt'] },
+    { symbol: 'DOT', name: 'Polkadot',  binanceSymbol: 'DOTUSDT', coingeckoId: 'polkadot',      keywords: ['dot', 'dotusdt', 'polkadot', '폴카닷', 'dot/usdt', 'dot-usdt'] }
+  ];
+
+  const ASSET_BY_KEY = new Map();
+  const PHRASE_KEYS = [];
+
+  ASSET_CATALOG.forEach(asset => {
+    const synonyms = new Set([asset.symbol, asset.binanceSymbol, asset.name, ...(asset.keywords || [])]);
+    asset.normalizedSynonyms = new Set();
+    synonyms.forEach(value => {
+      if (!value) return;
+      const lower = String(value).toLowerCase().trim();
+      if (!lower) return;
+      const normalized = sanitizeKey(lower);
+      if (!normalized) return;
+      asset.normalizedSynonyms.add(normalized);
+      if (!ASSET_BY_KEY.has(normalized)) {
+        ASSET_BY_KEY.set(normalized, asset);
+      }
+      if (!/^[0-9a-z]+$/.test(normalized)) {
+        PHRASE_KEYS.push({ key: normalized, asset });
+      }
+    });
+  });
+
+  const resolveAssetFromToken = (token) => {
+    if (!token) return null;
+    const normalized = sanitizeKey(token);
+    return ASSET_BY_KEY.get(normalized) || null;
+  };
+
+  const hasPriceKeyword = (lower, collapsed) => PRICE_KEYWORD_CONFIG.some(({ raw, normalized }) => {
+    return (raw && lower.includes(raw)) || (normalized && collapsed.includes(normalized));
+  });
+
+  const detectPriceIntent = (raw) => {
+    const text = String(raw || '');
+    const trimmed = text.trim();
+    if (!trimmed) return null;
+    const lower = trimmed.toLowerCase();
+    const collapsed = sanitizeKey(lower);
+    const tokens = lower.split(/[^0-9a-z가-힣]+/).map(t => sanitizeKey(t)).filter(Boolean);
+
+    let asset = null;
+    for (const token of tokens) {
+      const candidate = ASSET_BY_KEY.get(token);
+      if (candidate) { asset = candidate; break; }
+    }
+    if (!asset) {
+      for (const { key, asset: candidate } of PHRASE_KEYS) {
+        if (collapsed.includes(key)) { asset = candidate; break; }
+      }
+    }
+    if (!asset) return null;
+
+    const keywordHit = hasPriceKeyword(lower, collapsed);
+    const sanitizedTrimmed = sanitizeKey(trimmed.replace(/[?!\.]+$/g, ''));
+    const directMatch = sanitizedTrimmed && asset.normalizedSynonyms.has(sanitizedTrimmed);
+    const tokensWithoutPrice = tokens.filter(t => !PRICE_KEYWORD_SET.has(t));
+    const onlyAssetToken = tokensWithoutPrice.length === 1 && ASSET_BY_KEY.get(tokensWithoutPrice[0]) === asset;
+
+    if (!keywordHit && !directMatch && !onlyAssetToken) return null;
+
+    return asset;
+  };
+
+  const fetchFastPrice = async (symbol) => {
+    const pair = String(symbol || '').toUpperCase();
+    if (!pair) throw new Error('거래쌍이 설정되지 않았어요.');
+    const u = new URL('/api/price/fast', window.location.origin);
+    u.searchParams.set('symbol', pair);
+    const r = await fetch(u);
+    if (!r.ok) throw new Error('실시간 시세 API 호출에 실패했어요.');
+    const data = await r.json();
+    const price = Number(data.price);
+    if (!Number.isFinite(price)) throw new Error('시세 데이터 형식이 올바르지 않아요.');
+    return { price, source: data.source || 'fast', cached: Boolean(data.cached), pair };
+  };
+
+  const fetchCoinGeckoMarket = async (id) => {
+    const coinId = String(id || '').trim();
+    if (!coinId) throw new Error('코인 ID가 설정되지 않았어요.');
+    const u = new URL('/api/coins/markets', window.location.origin);
+    u.searchParams.set('vs_currency', 'usd');
+    u.searchParams.set('ids', coinId);
+    u.searchParams.set('price_change_percentage', '1h,24h,7d');
+    const r = await fetch(u);
+    if (!r.ok) throw new Error('시세 상세 API 호출에 실패했어요.');
+    const arr = await r.json();
+    if (!Array.isArray(arr) || !arr.length) throw new Error('코인 데이터를 찾을 수 없어요.');
+    const c = arr[0] || {};
+    return {
+      name: c.name,
+      symbol: c.symbol ? String(c.symbol).toUpperCase() : '',
+      price: Number(c.current_price),
+      high24h: Number(c.high_24h),
+      low24h: Number(c.low_24h),
+      marketCap: Number(c.market_cap),
+      change1h: Number(c.price_change_percentage_1h_in_currency),
+      change24h: Number(c.price_change_percentage_24h_in_currency),
+      change7d: Number(c.price_change_percentage_7d_in_currency)
+    };
+  };
+
+  const fetchPriceForAsset = async (asset) => {
+    const fastPromise = asset?.binanceSymbol ? fetchFastPrice(asset.binanceSymbol) : Promise.reject(new Error('실시간 시세가 지원되지 않아요.'));
+    const cgPromise = asset?.coingeckoId ? fetchCoinGeckoMarket(asset.coingeckoId) : Promise.reject(new Error('세부 시세가 지원되지 않아요.'));
+    const [fastRes, cgRes] = await Promise.allSettled([fastPromise, cgPromise]);
+
+    const fastData = fastRes.status === 'fulfilled' ? fastRes.value : null;
+    const cgData = cgRes.status === 'fulfilled' ? cgRes.value : null;
+
+    if (!fastData && !cgData) {
+      const err = fastRes.status === 'rejected' ? fastRes.reason : cgRes.reason;
+      throw err instanceof Error ? err : new Error('가격 데이터를 가져올 수 없어요.');
+    }
+
+    const price = fastData?.price ?? cgData?.price;
+    if (!Number.isFinite(Number(price))) {
+      throw new Error('가격 데이터를 가져올 수 없어요.');
+    }
+
+    return {
+      name: asset.name || cgData?.name || asset.symbol,
+      symbol: asset.symbol || cgData?.symbol || '',
+      pair: fastData?.pair || asset.binanceSymbol || asset.symbol,
+      price: Number(price),
+      priceSource: fastData?.source || (cgData ? 'coingecko' : ''),
+      priceCached: fastData?.cached || false,
+      currency: asset.currency || 'USD',
+      high24h: cgData?.high24h,
+      low24h: cgData?.low24h,
+      marketCap: cgData?.marketCap,
+      change1h: cgData?.change1h,
+      change24h: cgData?.change24h,
+      change7d: cgData?.change7d
+    };
   };
 
   // ---------- APIs ----------
@@ -116,41 +306,35 @@
     return j.reply || '(no content)';
   }
 
-  // CoinGecko 프록시 사용 (/api/coins/markets)
-  const coinIdMap = {
-    BTC:'bitcoin', ETH:'ethereum', SOL:'solana', XRP:'ripple', BNB:'binancecoin',
-    ADA:'cardano', DOGE:'dogecoin', AVAX:'avalanche-2', TRX:'tron',
-    TON:'the-open-network', MATIC:'matic-network', DOT:'polkadot'
-  };
+  const isFiniteNumber = (v) => Number.isFinite(Number(v));
 
-  async function fetchPrice(symRaw){
-    const sym = String(symRaw||'').trim().toUpperCase();
-    const id = coinIdMap[sym];
-    if(!id) throw new Error(`지원하지 않는 심볼이에요: ${sym}`);
-    const u = new URL('/api/coins/markets', window.location.origin);
-    u.searchParams.set('vs_currency','usd');
-    u.searchParams.set('ids',id);
-    u.searchParams.set('price_change_percentage','1h,24h,7d');
-    const r = await fetch(u);
-    if(!r.ok) throw new Error('가격 API 오류');
-    const arr = await r.json();
-    if(!arr?.length) throw new Error('코인 데이터를 찾을 수 없어요.');
-    const c = arr[0];
-    return {
-      name:c.name, symbol:sym, price:c.current_price, high24h:c.high_24h, low24h:c.low_24h,
-      mc:c.market_cap, change1h:c.price_change_percentage_1h_in_currency,
-      change24h:c.price_change_percentage_24h_in_currency,
-      change7d:c.price_change_percentage_7d_in_currency
-    };
-  }
+  const renderPriceCard = (x) => {
+    const changeParts = [];
+    if (isFiniteNumber(x.change1h)) changeParts.push(`1h ${fmt.pct(x.change1h)}`);
+    if (isFiniteNumber(x.change24h)) changeParts.push(`24h ${fmt.pct(x.change24h)}`);
+    if (isFiniteNumber(x.change7d)) changeParts.push(`7d ${fmt.pct(x.change7d)}`);
+    const changeLine = changeParts.length ? `&nbsp; ${changeParts.join(' · ')}` : '';
 
-  const renderPriceCard = (x) => `
+    const metaParts = [];
+    if (isFiniteNumber(x.high24h)) metaParts.push(`24h 고가 ${fmt.money(x.high24h, x.currency)}`);
+    if (isFiniteNumber(x.low24h)) metaParts.push(`저가 ${fmt.money(x.low24h, x.currency)}`);
+    if (isFiniteNumber(x.marketCap)) metaParts.push(`시총 ${fmt.money(x.marketCap, x.currency)}`);
+    const metaLine = metaParts.length ? `<div style="opacity:.82;margin-top:4px">${metaParts.join(' · ')}</div>` : '';
+
+    const sourceParts = [];
+    if (x.priceSource) sourceParts.push(x.priceSource.toUpperCase());
+    if (x.pair && x.pair !== x.symbol) sourceParts.push(x.pair);
+    const sourceNote = sourceParts.length
+      ? ` <span style="font-size:12px;opacity:.72">· ${sourceParts.join(' · ')}</span>`
+      : '';
+
+    return `
     <div>
       <div style="font-weight:700;margin-bottom:6px">${x.name} (${x.symbol})</div>
-      <div>가격: <b>${fmt.money(x.price)}</b>
-        &nbsp; 1h ${fmt.pct(x.change1h)} · 24h ${fmt.pct(x.change24h)} · 7d ${fmt.pct(x.change7d)}</div>
-      <div style="opacity:.82;margin-top:4px">24h 고가 ${fmt.money(x.high24h)} · 저가 ${fmt.money(x.low24h)} · 시총 ${fmt.money(x.mc)}</div>
+      <div>가격: <b>${fmt.money(x.price, x.currency)}</b>${sourceNote}${changeLine}</div>
+      ${metaLine}
     </div>`;
+  };
 
   // ---------- router ----------
   async function handleInput(raw){
@@ -174,11 +358,27 @@
     }
 
     // /price
-    const mP = raw.match(/^\/price\s+([A-Za-z]{2,10})$/i);
+    const mP = raw.match(/^\/price\s+([A-Za-z0-9\/_-]{2,20})$/i);
     if(mP){
+      const symLabel = String(mP[1] || '').trim().toUpperCase();
       showTyping();
       try{
-        const info = await fetchPrice(mP[1]);
+        const asset = resolveAssetFromToken(mP[1]);
+        if(!asset) throw new Error(`지원하지 않는 심볼이에요: ${symLabel}`);
+        const info = await fetchPriceForAsset(asset);
+        hideTyping();
+        addMessage(renderPriceCard(info), false);
+      }catch(e){
+        hideTyping(); addMessage(`가격 조회 실패: ${e.message}`, false);
+      }
+      return;
+    }
+
+    const autoAsset = detectPriceIntent(raw);
+    if(autoAsset){
+      showTyping();
+      try{
+        const info = await fetchPriceForAsset(autoAsset);
         hideTyping();
         addMessage(renderPriceCard(info), false);
       }catch(e){


### PR DESCRIPTION
## Summary
- add a catalog of supported crypto assets with keyword-based intent detection so phrases like "비트코인", "btc", or "btcusdt" trigger pricing
- fetch prices via the fast multi-exchange endpoint with a CoinGecko fallback and render richer price cards in the chat UI
- update the `/price` command to accept more symbols and share the new fetching logic for consistent responses

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c99be074d0832f9d227b4cec8dc2e8