### PR TITLE
feat: add translated crypto news feed

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -821,7 +821,7 @@
       <li><a href="/menu/orbits.html">Orbits</a></li>
       <li><a href="/menu/method.html">Method</a></li>
       <li><a href="/menu/psyche.html">Psyche</a></li>
-      <li><a href="/menu/ECHOES/">Echoes</a></li>
+      <li><a href="/menu/echoes/">Echoes</a></li>
       <li><a href="/menu/constellation.html">Constellation</a></li>
       <li><a href="/menu/portal.html">Portal</a></li>
     </ul>
@@ -960,7 +960,7 @@
 </div>
 <div class="menu-section">
   <ul class="menu-items">
-    <li class="menu-item"><a href="menu/ECHOES/" class="menu-link">ECHOES (OBSERVATIONS / NEWS)<span class="korean-desc">사건의 메아리, 관찰 기록</span></a></li>
+    <li class="menu-item"><a href="menu/echoes/" class="menu-link">ECHOES (OBSERVATIONS / NEWS)<span class="korean-desc">사건의 메아리, 관찰 기록</span></a></li>
     <li class="menu-item"><a href="menu/constellation.html" class="menu-link">CONSTELLATION (COMMUNITY)<span class="korean-desc">사용자 커뮤니티</span></a></li>
     <li class="menu-item"><a href="menu/beacons.html" class="menu-link">BEACONS (ALERTS)<span class="korean-desc">주의</span></a></li>
 </ul>

--- a/apps/web/menu/echoes.html
+++ b/apps/web/menu/echoes.html
@@ -2,10 +2,10 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=ECHOES/">
+  <meta http-equiv="refresh" content="0; url=echoes/">
   <title>ECHOES | Two.4</title>
   <script>
-    window.location.replace('ECHOES/');
+    window.location.replace('echoes/');
   </script>
   <style>
     body {
@@ -24,6 +24,6 @@
   </style>
 </head>
 <body>
-  <p>Redirecting to <a href="ECHOES/">ECHOES (OBSERVATIONS / NEWS)</a>…</p>
+  <p>Redirecting to <a href="echoes/">ECHOES (OBSERVATIONS / NEWS)</a>…</p>
 </body>
 </html>

--- a/apps/web/menu/echoes/api.js
+++ b/apps/web/menu/echoes/api.js
@@ -1,0 +1,43 @@
+const CACHE_TTL_MS = 2 * 60 * 1000;
+let cached = { items: null, timestamp: 0, limit: 0 };
+
+function buildQuery(limit) {
+  const params = new URLSearchParams();
+  if (Number.isFinite(limit) && limit > 0) {
+    params.set('limit', String(limit));
+  }
+  return params.toString();
+}
+
+export async function fetchCryptoNews(limit = 12) {
+  const now = Date.now();
+  if (cached.items && (now - cached.timestamp) < CACHE_TTL_MS && cached.limit >= limit) {
+    return cached.items.slice(0, limit);
+  }
+
+  const query = buildQuery(limit);
+  const url = query ? `/api/crypto-news?${query}` : '/api/crypto-news';
+  const response = await fetch(url, {
+    headers: {
+      'Accept': 'application/json',
+    },
+  });
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`HTTP ${response.status}: ${text || 'Failed to fetch crypto news'}`);
+  }
+
+  const data = await response.json();
+  if (!data || !Array.isArray(data.items)) {
+    throw new Error('Unexpected response format from /api/crypto-news');
+  }
+
+  cached = {
+    items: data.items,
+    timestamp: now,
+    limit: data.items.length,
+  };
+
+  return data.items.slice(0, limit);
+}

--- a/apps/web/menu/echoes/echoes.js
+++ b/apps/web/menu/echoes/echoes.js
@@ -1,0 +1,374 @@
+import { fetchCryptoNews } from './api.js';
+
+const HEADLINE_COUNT = 3;
+const DEFAULT_STATUS = '최신 크립토 뉴스를 불러오는 중입니다...';
+let latestItems = [];
+let currentQuery = '';
+
+function setNewsStatus(message, { error = false, hidden = false } = {}) {
+  const statusEl = document.getElementById('newsStatus');
+  if (!statusEl) return;
+  statusEl.textContent = message;
+  statusEl.classList.toggle('error', Boolean(error));
+  statusEl.classList.toggle('hidden', Boolean(hidden));
+}
+
+function createStars() {
+  const starsContainer = document.getElementById('stars');
+  if (!starsContainer) return;
+  const numStars = 100;
+  starsContainer.innerHTML = '';
+  for (let i = 0; i < numStars; i += 1) {
+    const star = document.createElement('div');
+    star.className = 'star';
+    star.style.left = `${Math.random() * 100}%`;
+    star.style.top = `${Math.random() * 100}%`;
+    star.style.animationDelay = `${Math.random() * 3}s`;
+    starsContainer.appendChild(star);
+  }
+}
+
+function initializeNewsCards() {
+  document.querySelectorAll('.news-card').forEach((card) => {
+    if (card.dataset.hoverBound === '1') return;
+    card.dataset.hoverBound = '1';
+    card.addEventListener('mouseenter', () => {
+      card.style.transform = 'translateY(-2px) scale(1.01)';
+    });
+    card.addEventListener('mouseleave', () => {
+      card.style.transform = 'translateY(0) scale(1)';
+    });
+  });
+}
+
+function initializeThemeToggle() {
+  const themeCheckbox = document.getElementById('theme-checkbox');
+  if (!themeCheckbox) return;
+  const savedTheme = localStorage.getItem('echoes-theme');
+  if (savedTheme === 'light') {
+    document.body.classList.add('light-mode');
+    themeCheckbox.checked = true;
+  }
+  document.body.classList.toggle('light-mode', themeCheckbox.checked);
+  themeCheckbox.addEventListener('change', () => {
+    const isLight = themeCheckbox.checked;
+    document.body.classList.toggle('light-mode', isLight);
+    localStorage.setItem('echoes-theme', isLight ? 'light' : 'dark');
+  });
+}
+
+function showNotification(message) {
+  const notification = document.createElement('div');
+  notification.style.cssText = [
+    'position: fixed',
+    'top: 80px',
+    'right: 20px',
+    'background: var(--card-bg)',
+    'color: var(--text-primary)',
+    'padding: 12px 20px',
+    'border-radius: 8px',
+    'border: 1px solid var(--border-color)',
+    'backdrop-filter: blur(10px)',
+    'z-index: 1000',
+    'font-size: 0.9rem',
+    'box-shadow: 0 4px 20px rgba(0,0,0,0.3)',
+    'transform: translateX(100%)',
+    'transition: transform 0.3s ease',
+  ].join(';');
+  notification.textContent = message;
+  document.body.appendChild(notification);
+  requestAnimationFrame(() => {
+    notification.style.transform = 'translateX(0)';
+  });
+  setTimeout(() => {
+    notification.style.transform = 'translateX(100%)';
+  }, 3000);
+  setTimeout(() => {
+    notification.remove();
+  }, 3600);
+}
+
+function initializeNotifications() {
+  const notificationCheckbox = document.getElementById('notification-checkbox');
+  const notificationBtn = document.querySelector('.notification-btn');
+  if (!notificationCheckbox || !notificationBtn) return;
+  const savedState = localStorage.getItem('echoes-notifications');
+  if (savedState === 'true') {
+    notificationCheckbox.checked = true;
+  }
+  notificationBtn.classList.toggle('active', notificationCheckbox.checked);
+  const syncState = () => {
+    const isActive = notificationCheckbox.checked;
+    notificationBtn.classList.toggle('active', isActive);
+    localStorage.setItem('echoes-notifications', isActive ? 'true' : 'false');
+    showNotification(isActive ? '알림이 활성화되었습니다! 🔔' : '알림이 비활성화되었습니다. 🔕');
+  };
+  notificationCheckbox.addEventListener('change', syncState);
+}
+
+function initializeMobileMenu() {
+  const mobileMenuBtn = document.getElementById('mobileMenuBtn');
+  const navMenu = document.getElementById('navMenu');
+  if (!mobileMenuBtn || !navMenu) return;
+  navMenu.setAttribute('aria-hidden', 'true');
+  mobileMenuBtn.setAttribute('aria-expanded', 'false');
+  mobileMenuBtn.addEventListener('click', () => {
+    const isActive = navMenu.classList.toggle('active');
+    navMenu.setAttribute('aria-hidden', isActive ? 'false' : 'true');
+    mobileMenuBtn.setAttribute('aria-expanded', isActive ? 'true' : 'false');
+  });
+}
+
+function formatTimeAgo(dateString) {
+  if (!dateString) return '';
+  const date = new Date(dateString);
+  if (Number.isNaN(date.getTime())) return '';
+  const diff = Date.now() - date.getTime();
+  const minute = 60 * 1000;
+  const hour = 60 * minute;
+  const day = 24 * hour;
+  if (diff < minute) return '방금 전';
+  if (diff < hour) return `${Math.floor(diff / minute)}분 전`;
+  if (diff < day) return `${Math.floor(diff / hour)}시간 전`;
+  if (diff < day * 7) return `${Math.floor(diff / day)}일 전`;
+  return date.toLocaleDateString('ko-KR', { month: 'short', day: 'numeric' });
+}
+
+function getCategoryLabel(item) {
+  if (!item) return 'Crypto';
+  if (item.category) return item.category;
+  if (Array.isArray(item.keywords) && item.keywords.length > 0) return item.keywords[0];
+  if (item.originalCategory) return item.originalCategory;
+  return 'Crypto';
+}
+
+function createNewsCard(item) {
+  const card = document.createElement('article');
+  card.className = 'news-card';
+  const searchText = [
+    item.title,
+    item.summary,
+    item.originalTitle,
+    item.originalSummary,
+    item.source,
+    (item.keywords || []).join(' '),
+  ].filter(Boolean).join(' ').toLowerCase();
+  card.dataset.search = searchText;
+
+  const content = document.createElement('div');
+  content.className = 'news-content';
+
+  const meta = document.createElement('div');
+  meta.className = 'news-meta';
+
+  const category = document.createElement('span');
+  category.className = 'news-category';
+  category.textContent = getCategoryLabel(item);
+
+  const time = document.createElement('span');
+  time.className = 'news-time';
+  time.textContent = formatTimeAgo(item.publishedAt || item.pubDate);
+
+  meta.append(category, time);
+  content.appendChild(meta);
+
+  const title = document.createElement('h3');
+  title.className = 'news-title';
+  title.textContent = item.title || item.originalTitle || '제목 없음';
+  content.appendChild(title);
+
+  if (item.summary || item.originalSummary) {
+    const summary = document.createElement('p');
+    summary.className = 'news-summary';
+    summary.textContent = item.summary || item.originalSummary || '';
+    content.appendChild(summary);
+  }
+
+  const link = document.createElement('a');
+  link.className = 'news-link';
+  link.textContent = '전체 기사 보기';
+  if (item.link) {
+    link.href = item.link;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.setAttribute('aria-label', `${title.textContent} 원문 보기`);
+  } else {
+    link.href = '#';
+    link.classList.add('disabled');
+    link.setAttribute('aria-disabled', 'true');
+  }
+  content.appendChild(link);
+
+  const imageWrapper = document.createElement('div');
+  imageWrapper.className = 'news-image';
+  if (item.imageUrl) {
+    const img = document.createElement('img');
+    img.src = item.imageUrl;
+    img.alt = item.title || item.originalTitle || '뉴스 이미지';
+    img.loading = 'lazy';
+    imageWrapper.appendChild(img);
+  } else {
+    imageWrapper.textContent = 'IMAGE';
+  }
+
+  card.append(content, imageWrapper);
+
+  card.addEventListener('click', (event) => {
+    if (event.target instanceof HTMLElement && event.target.closest('a')) return;
+    if (item.link) window.open(item.link, '_blank', 'noopener');
+  });
+
+  return card;
+}
+
+function renderNews(items) {
+  const grid = document.getElementById('newsGrid');
+  if (!grid) return;
+  latestItems = items;
+  grid.innerHTML = '';
+  grid.setAttribute('aria-busy', 'false');
+
+  if (!items || items.length === 0) {
+    setNewsStatus('표시할 뉴스가 없습니다. 잠시 후 다시 시도해 주세요.');
+    return;
+  }
+
+  const fragment = document.createDocumentFragment();
+  items.forEach((item) => {
+    fragment.appendChild(createNewsCard(item));
+  });
+  grid.appendChild(fragment);
+  initializeNewsCards();
+
+  if (currentQuery) {
+    filterNews(currentQuery);
+  } else {
+    setNewsStatus(`총 ${items.length}건의 최신 뉴스가 업데이트되었습니다.`);
+  }
+}
+
+function updateHeadlines(items) {
+  const headlines = document.querySelectorAll('#headlineList .headline-item');
+  headlines.forEach((headline, index) => {
+    const data = items[index];
+    const categoryEl = headline.querySelector('.headline-category');
+    const titleEl = headline.querySelector('.headline-title');
+    const timeEl = headline.querySelector('.headline-time');
+
+    if (!categoryEl || !titleEl || !timeEl) return;
+
+    if (data) {
+      categoryEl.textContent = getCategoryLabel(data);
+      titleEl.textContent = data.title || data.originalTitle || '';
+      timeEl.textContent = formatTimeAgo(data.publishedAt || data.pubDate);
+      headline.dataset.link = data.link || '';
+      headline.setAttribute('tabindex', '0');
+      headline.setAttribute('role', 'link');
+      headline.classList.remove('headline-empty');
+    } else {
+      categoryEl.textContent = 'Crypto';
+      titleEl.textContent = '새로운 뉴스를 기다리는 중입니다.';
+      timeEl.textContent = '';
+      headline.dataset.link = '';
+      headline.removeAttribute('role');
+      headline.removeAttribute('tabindex');
+      headline.classList.add('headline-empty');
+    }
+
+    if (headline.dataset.bindListener === '1') return;
+    headline.dataset.bindListener = '1';
+    headline.addEventListener('click', () => {
+      if (headline.dataset.link) {
+        window.open(headline.dataset.link, '_blank', 'noopener');
+      }
+    });
+    headline.addEventListener('keydown', (event) => {
+      if ((event.key === 'Enter' || event.key === ' ') && headline.dataset.link) {
+        event.preventDefault();
+        window.open(headline.dataset.link, '_blank', 'noopener');
+      }
+    });
+  });
+}
+
+function filterNews(query) {
+  currentQuery = query;
+  const q = (query || '').trim().toLowerCase();
+  const cards = document.querySelectorAll('#newsGrid .news-card');
+  if (cards.length === 0) return;
+  let visibleCount = 0;
+  cards.forEach((card) => {
+    const match = !q || (card.dataset.search || '').includes(q);
+    card.style.display = match ? '' : 'none';
+    if (match) visibleCount += 1;
+  });
+  if (!q) {
+    setNewsStatus(`총 ${latestItems.length}건의 최신 뉴스가 업데이트되었습니다.`);
+  } else if (visibleCount === 0) {
+    setNewsStatus('검색 결과가 없습니다.', { error: false });
+  } else {
+    setNewsStatus(`검색 결과 ${visibleCount}건이 표시됩니다.`);
+  }
+}
+
+function initializeSearch() {
+  const searchInput = document.querySelector('.search-input');
+  if (!searchInput) return;
+  searchInput.addEventListener('input', (event) => {
+    filterNews(event.target.value);
+  });
+  searchInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      filterNews(searchInput.value);
+    }
+  });
+}
+
+async function loadCryptoNews() {
+  const grid = document.getElementById('newsGrid');
+  if (grid) {
+    grid.setAttribute('aria-busy', 'true');
+  }
+  setNewsStatus(DEFAULT_STATUS);
+  try {
+    const items = await fetchCryptoNews(12);
+    renderNews(items);
+    updateHeadlines(items.slice(0, HEADLINE_COUNT));
+  } catch (error) {
+    console.error('Failed to load crypto news:', error);
+    setNewsStatus('뉴스를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.', { error: true });
+  }
+}
+
+function updatePrices() {
+  const prices = document.querySelectorAll('.crypto-price');
+  prices.forEach((priceEl) => {
+    const text = priceEl.textContent.trim();
+    if (!text.includes('$')) return;
+    if (!priceEl.dataset.precision) {
+      const decimals = (text.split('.')[1] || '').replace(/[^0-9]/g, '').length;
+      priceEl.dataset.precision = String(Math.min(decimals, 4));
+    }
+    const precision = Number(priceEl.dataset.precision || '0');
+    const numeric = parseFloat(text.replace(/[^0-9.]/g, ''));
+    if (Number.isNaN(numeric)) return;
+    const change = (Math.random() - 0.5) * 0.02;
+    const newPrice = numeric * (1 + change);
+    priceEl.textContent = `$${newPrice.toLocaleString(undefined, {
+      minimumFractionDigits: precision,
+      maximumFractionDigits: precision,
+    })}`;
+  });
+}
+
+window.addEventListener('DOMContentLoaded', () => {
+  createStars();
+  initializeMobileMenu();
+  initializeSearch();
+  initializeThemeToggle();
+  initializeNotifications();
+  loadCryptoNews();
+  updatePrices();
+  setInterval(updatePrices, 10000);
+});

--- a/apps/web/menu/echoes/index.html
+++ b/apps/web/menu/echoes/index.html
@@ -509,7 +509,39 @@
             display: grid;
             gap: 20px;
         }
-        
+
+        .news-status {
+            margin: 0 0 24px;
+            padding: 18px 20px;
+            border: 1px dashed var(--border-color);
+            border-radius: 10px;
+            background: rgba(138, 43, 226, 0.05);
+            color: var(--text-secondary);
+            font-size: 0.95rem;
+            text-align: center;
+            line-height: 1.5;
+            transition: all 0.3s ease;
+        }
+
+        body.light-mode .news-status {
+            background: rgba(138, 43, 226, 0.08);
+        }
+
+        .news-status.error {
+            border-color: rgba(255, 82, 82, 0.6);
+            background: rgba(255, 82, 82, 0.08);
+            color: #ff9b9b;
+        }
+
+        body.light-mode .news-status.error {
+            color: #d62839;
+            background: rgba(255, 82, 82, 0.12);
+        }
+
+        .news-status.hidden {
+            display: none;
+        }
+
         .news-card {
             background: var(--card-bg);
             border: 1px solid var(--border-color);
@@ -626,7 +658,13 @@
             letter-spacing: 1px;
             font-family: 'Orbitron', monospace;
         }
-        
+
+        .news-link.disabled {
+            opacity: 0.5;
+            pointer-events: none;
+            cursor: default;
+        }
+
         .news-link::after {
             content: "▶";
             margin-left: 8px;
@@ -859,7 +897,7 @@
                     <li><a href="/menu/orbits.html" data-tooltip="지표, 신호">Orbits</a></li>
                     <li><a href="/menu/method.html" data-tooltip="기법">Method</a></li>
                     <li><a href="/menu/psyche.html" data-tooltip="심법">Psyche</a></li>
-                    <li><a href="/menu/ECHOES/" class="active" data-tooltip="뉴스, 관찰기록">Echoes</a></li>
+                    <li><a href="/menu/echoes/" class="active" data-tooltip="뉴스, 관찰기록">Echoes</a></li>
                     <li><a href="/menu/constellation.html" data-tooltip="커뮤니티">Constellation</a></li>
                     <li><a href="/menu/portal.html" data-tooltip="로그인/로그아웃">Portal</a></li>
                 </ul>
@@ -889,23 +927,23 @@
             <h1 class="logo">ECHOES</h1>
             <p class="tagline" data-kr="최신 크립토 뉴스를 한 곳에서">Latest Crypto News in One Place</p>
             
-            <div class="headlines">
-                <div class="headline-item">
-                    <div class="headline-category">Bitcoin</div>
-                    <div class="headline-title">Bitcoin ETF Sees Record $2.1B Inflow as Institutional Demand Surges</div>
-                    <div class="headline-time">12 Minutes Ago</div>
+            <div class="headlines" id="headlineList">
+                <div class="headline-item" data-headline-index="0">
+                    <div class="headline-category">Loading</div>
+                    <div class="headline-title">최신 헤드라인을 불러오는 중...</div>
+                    <div class="headline-time"></div>
                 </div>
-                
-                <div class="headline-item">
-                    <div class="headline-category">Ethereum</div>
-                    <div class="headline-title">Ethereum Layer 2 Solutions Process Over $1M Transactions Per Second</div>
-                    <div class="headline-time">28 Minutes Ago</div>
+
+                <div class="headline-item" data-headline-index="1">
+                    <div class="headline-category">Loading</div>
+                    <div class="headline-title">잠시만 기다려 주세요.</div>
+                    <div class="headline-time"></div>
                 </div>
-                
-                <div class="headline-item">
-                    <div class="headline-category">Market</div>
-                    <div class="headline-title">Global Crypto Market Cap Reaches New High of $3.2 Trillion</div>
-                    <div class="headline-time">45 Minutes Ago</div>
+
+                <div class="headline-item" data-headline-index="2">
+                    <div class="headline-category">Loading</div>
+                    <div class="headline-title">가장 중요한 크립토 뉴스를 준비 중입니다.</div>
+                    <div class="headline-time"></div>
                 </div>
             </div>
         </header>
@@ -913,61 +951,8 @@
         <div class="main-content">
             <main class="news-section">
                 <h2 class="section-title">Intelligence Feed</h2>
-                <div class="news-grid" id="newsGrid">
-                    <article class="news-card">
-                        <div class="news-content">
-                            <div class="news-meta">
-                                <span class="news-category">Bitcoin</span>
-                                <span class="news-time">2 Hours Ago</span>
-                            </div>
-                            <h3 class="news-title">Bitcoin Surge: Institutional Giants Trigger $2.1B ETF Explosion</h3>
-                            <p class="news-summary">Wall Street titans are reshaping the cryptocurrency landscape as record-breaking institutional flows drive Bitcoin to unprecedented heights, signaling a seismic shift in digital asset adoption.</p>
-                            <a href="#" class="news-link">Deep Dive Analysis</a>
-                        </div>
-                        <div class="news-image"></div>
-                    </article>
-                    
-                    <article class="news-card">
-                        <div class="news-content">
-                            <div class="news-meta">
-                                <span class="news-category">Ethereum</span>
-                                <span class="news-time">4 Hours Ago</span>
-                            </div>
-                            <h3 class="news-title">Ethereum's Layer 2 Revolution: Breaking the Million TPS Barrier</h3>
-                            <p class="news-summary">The Ethereum ecosystem reaches a critical inflection point as Layer 2 solutions achieve breakthrough scalability, processing over one million transactions per second while maintaining decentralization.</p>
-                            <a href="#" class="news-link">Technical Breakdown</a>
-                        </div>
-                        <div class="news-image"></div>
-                    </article>
-                    
-                    <article class="news-card">
-                        <div class="news-content">
-                            <div class="news-meta">
-                                <span class="news-category">DeFi</span>
-                                <span class="news-time">6 Hours Ago</span>
-                            </div>
-                            <h3 class="news-title">Zero-Fee Trading Era: DeFi Protocol Disrupts Traditional Finance</h3>
-                            <p class="news-summary">A groundbreaking decentralized exchange protocol eliminates all trading fees while maintaining institutional-grade liquidity and security, potentially triggering the next DeFi summer.</p>
-                            <a href="#" class="news-link">Protocol Analysis</a>
-                        </div>
-                        <div class="news-image"></div>
-                    </article>
-                    
-                    <article class="news-card">
-                        <div class="news-content">
-                            <div class="news-meta">
-                                <span class="news-category">Regulation</span>
-                                <span class="news-time">8 Hours Ago</span>
-                            </div>
-                            <h3 class="news-title">Global Crypto Consensus: Regulatory Framework Unifies Markets</h3>
-                            <p class="news-summary">International regulatory bodies achieve historic consensus on comprehensive cryptocurrency oversight framework, bringing unprecedented clarity and legitimacy to global digital asset markets.</p>
-                            <a href="#" class="news-link">Regulatory Impact</a>
-                        </div>
-                        <div class="news-image">
-                            <img src="https://via.placeholder.com/160x120/8a2be2/ffffff?text=NEWS" alt="News Image">
-                        </div>
-                    </article>
-                </div>
+                <div class="news-status" id="newsStatus" role="status" aria-live="polite">최신 크립토 뉴스를 불러오는 중입니다...</div>
+                <div class="news-grid" id="newsGrid" aria-live="polite" aria-busy="true"></div>
             </main>
             
             <aside class="sidebar">
@@ -1022,185 +1007,6 @@
         </div>
     </div>
     
-    <script>
-        function createStars() {
-            const starsContainer = document.getElementById('stars');
-            if (!starsContainer) return;
-            
-            const numStars = 100;
-            starsContainer.innerHTML = '';
-            
-            for (let i = 0; i < numStars; i++) {
-                const star = document.createElement('div');
-                star.className = 'star';
-                star.style.left = Math.random() * 100 + '%';
-                star.style.top = Math.random() * 100 + '%';
-                star.style.animationDelay = Math.random() * 3 + 's';
-                starsContainer.appendChild(star);
-            }
-        }
-        
-        function initializeNewsCards() {
-            const newsCards = document.querySelectorAll('.news-card');
-            newsCards.forEach(card => {
-                card.addEventListener('mouseenter', function() {
-                    this.style.transform = 'translateY(-2px) scale(1.01)';
-                });
-                card.addEventListener('mouseleave', function() {
-                    this.style.transform = 'translateY(0) scale(1)';
-                });
-            });
-        }
-        
-        function initializeThemeToggle() {
-            const themeCheckbox = document.getElementById('theme-checkbox');
-            if (!themeCheckbox) return;
-
-            const savedTheme = localStorage.getItem('echoes-theme');
-            if (savedTheme === 'light') {
-                document.body.classList.add('light-mode');
-                themeCheckbox.checked = true;
-            }
-
-            document.body.classList.toggle('light-mode', themeCheckbox.checked);
-
-            themeCheckbox.addEventListener('change', () => {
-                const isLight = themeCheckbox.checked;
-                document.body.classList.toggle('light-mode', isLight);
-                localStorage.setItem('echoes-theme', isLight ? 'light' : 'dark');
-            });
-        }
-
-        function initializeNotifications() {
-            const notificationCheckbox = document.getElementById('notification-checkbox');
-            const notificationBtn = document.querySelector('.notification-btn');
-            if (!notificationCheckbox || !notificationBtn) return;
-
-            const savedState = localStorage.getItem('echoes-notifications');
-            if (savedState === 'true') {
-                notificationCheckbox.checked = true;
-            }
-
-            notificationBtn.classList.toggle('active', notificationCheckbox.checked);
-
-            const syncState = () => {
-                const isActive = notificationCheckbox.checked;
-                notificationBtn.classList.toggle('active', isActive);
-                localStorage.setItem('echoes-notifications', isActive ? 'true' : 'false');
-                showNotification(isActive ? '알림이 활성화되었습니다! 🔔' : '알림이 비활성화되었습니다. 🔕');
-            };
-            
-            notificationCheckbox.addEventListener('change', syncState);
-        }
-        
-        function showNotification(message) {
-            const notification = document.createElement('div');
-            notification.style.cssText = [
-                'position: fixed',
-                'top: 80px',
-                'right: 20px',
-                'background: var(--card-bg)',
-                'color: var(--text-primary)',
-                'padding: 12px 20px',
-                'border-radius: 8px',
-                'border: 1px solid var(--border-color)',
-                'backdrop-filter: blur(10px)',
-                'z-index: 1000',
-                'font-size: 0.9rem',
-                'box-shadow: 0 4px 20px rgba(0,0,0,0.3)',
-                'transform: translateX(100%)',
-                'transition: transform 0.3s ease'
-            ].join(';');
-            
-            notification.textContent = message;
-            document.body.appendChild(notification);
-            
-            requestAnimationFrame(() => {
-                notification.style.transform = 'translateX(0)';
-            });
-            
-            setTimeout(() => {
-                notification.style.transform = 'translateX(100%)';
-            }, 3000);
-            
-            setTimeout(() => {
-                if (notification.parentNode) {
-                    notification.parentNode.removeChild(notification);
-                }
-            }, 3500);
-        }
-        
-        function initializeMobileMenu() {
-            const mobileMenuBtn = document.getElementById('mobileMenuBtn');
-            const navMenu = document.getElementById('navMenu');
-            if (!mobileMenuBtn || !navMenu) return;
-            
-            mobileMenuBtn.addEventListener('click', () => {
-                navMenu.classList.toggle('active');
-            });
-            
-            document.addEventListener('click', (event) => {
-                if (!navMenu.contains(event.target) && !mobileMenuBtn.contains(event.target)) {
-                    navMenu.classList.remove('active');
-                }
-            });
-        }
-        
-        function initializeSearch() {
-            const searchInput = document.querySelector('.search-input');
-            const searchBtn = document.querySelector('.search-btn');
-            if (!searchInput || !searchBtn) return;
-            
-            const handleSearch = () => {
-                const query = searchInput.value.trim();
-                if (query) {
-                    console.log('Searching for:', query);
-                    alert('검색 기능: "' + query + '"를 검색합니다.');
-                }
-            };
-            
-            searchBtn.addEventListener('click', handleSearch);
-            searchInput.addEventListener('keypress', (e) => {
-                if (e.key === 'Enter') {
-                    handleSearch();
-                }
-            });
-        }
-        
-        function updatePrices() {
-            const prices = document.querySelectorAll('.crypto-price');
-            prices.forEach(price => {
-                const text = price.textContent.trim();
-                if (!text.includes('$')) return;
-                
-                if (!price.dataset.precision) {
-                    const decimals = (text.split('.')[1] || '').replace(/[^0-9]/g, '').length;
-                    price.dataset.precision = String(Math.min(decimals, 4));
-                }
-                
-                const precision = Number(price.dataset.precision || '0');
-                const numeric = parseFloat(text.replace(/[^0-9.]/g, ''));
-                if (Number.isNaN(numeric)) return;
-                
-                const change = (Math.random() - 0.5) * 0.02;
-                const newPrice = numeric * (1 + change);
-                price.textContent = '$' + newPrice.toLocaleString(undefined, {
-                    minimumFractionDigits: precision,
-                    maximumFractionDigits: precision
-                });
-            });
-        }
-        
-        document.addEventListener('DOMContentLoaded', () => {
-            createStars();
-            initializeNewsCards();
-            initializeMobileMenu();
-            initializeSearch();
-            initializeThemeToggle();
-            initializeNotifications();
-            updatePrices();
-            setInterval(updatePrices, 10000);
-        });
-    </script>
+    <script type="module" src="./echoes.js"></script>
 </body>
 </html>

--- a/apps/web/menu/header.html
+++ b/apps/web/menu/header.html
@@ -84,7 +84,7 @@
       <li><a href="/menu/orbits.html">Orbits</a></li>
       <li><a href="/menu/method.html">Method</a></li>
       <li><a href="/menu/psyche.html">Psyche</a></li>
-      <li><a href="/menu/ECHOES/">Echoes</a></li>
+      <li><a href="/menu/echoes/">Echoes</a></li>
       <li><a href="/menu/constellation.html">Constellation</a></li>
       <li><a href="/menu/portal.html">Portal</a></li>
     </ul>
@@ -121,7 +121,7 @@
     <li><a href="orbits.html">ORBITS (INDICATORS)</a></li>
     <li><a href="method.html">METHOD (TECHNIQUE)</a></li>
     <li><a href="psyche.html">PSYCHE</a></li>
-    <li><a href="ECHOES/">ECHOES (NEWS)</a></li>
+    <li><a href="echoes/">ECHOES (NEWS)</a></li>
     <li><a href="constellation.html">CONSTELLATION</a></li>
     <li><a href="beacons.html">BEACONS</a></li>
     <li><a href="portal.html">PORTAL</a></li>

--- a/server.js
+++ b/server.js
@@ -727,6 +727,298 @@ app.get('/api/news', async (req, res) => {
   }
 });
 
+const NEWSDATA_API_KEY = process.env.NEWSDATA_API_KEY || '';
+const NEWS_MODEL_ID = process.env.NEWS_MODEL_ID || MODEL_ID || 'openrouter/auto';
+const CRYPTO_NEWS_CACHE_TTL = 5 * 60 * 1000;
+const CRYPTO_KEYWORD_REGEX = /\b(crypto(?:currency)?|bitcoin|btc|ethereum|eth|blockchain|web3|defi|stablecoin|altcoin|token|solana|xrp|ripple|binance|coinbase|staking|layer\s*2|nft|dao|airdrops?)\b/i;
+
+app.get('/api/crypto-news', async (req, res) => {
+  try {
+    if (!NEWSDATA_API_KEY) {
+      setCorsAndCache(res);
+      return res.status(500).json({ error: 'NEWSDATA_API_KEY not set' });
+    }
+    if (!OPENROUTER_API_KEY) {
+      setCorsAndCache(res);
+      return res.status(500).json({ error: 'OPENROUTER_API_KEY not set' });
+    }
+
+    const rawLimit = Number.parseInt(req.query.limit, 10);
+    const limit = Math.min(Math.max(Number.isNaN(rawLimit) ? 12 : rawLimit, 1), 24);
+
+    const cacheKey = `CRYPTO_NEWS:${limit}`;
+    const cached = hit2(cacheKey, CRYPTO_NEWS_CACHE_TTL);
+    if (cached) {
+      setCorsAndCache(res);
+      res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+      return res.type(cached.ct).status(cached.status).send(cached.body);
+    }
+
+    const fetched = await fetchNewsdataArticles(limit * 3);
+    const filtered = dedupeArticles(fetched.filter(isCryptoArticle));
+
+    if (!filtered.length) {
+      const empty = { updatedAt: new Date().toISOString(), source: 'newsdata.io', items: [] };
+      const body = JSON.stringify(empty);
+      setCorsAndCache(res);
+      res.setHeader('Cache-Control', 'public, s-maxage=120, stale-while-revalidate=240');
+      res.type('application/json').status(200).send(body);
+      keep(cacheKey, { ok: true, status: 200, body, ct: 'application/json; charset=utf-8' });
+      return;
+    }
+
+    let items = [];
+    try {
+      items = await enrichArticlesWithOpenRouter(filtered, limit);
+    } catch (err) {
+      console.error('crypto-news enrich error:', err);
+      items = [];
+    }
+
+    if (!items.length) {
+      items = mapArticlesBasic(filtered, limit);
+    }
+
+    const payload = {
+      updatedAt: new Date().toISOString(),
+      source: 'newsdata.io',
+      items: items.slice(0, limit),
+    };
+    const body = JSON.stringify(payload);
+    setCorsAndCache(res);
+    res.setHeader('Cache-Control', 'public, s-maxage=300, stale-while-revalidate=600');
+    res.type('application/json').status(200).send(body);
+    keep(cacheKey, { ok: true, status: 200, body, ct: 'application/json; charset=utf-8' });
+  } catch (error) {
+    console.error('crypto-news error:', error);
+    setCorsAndCache(res);
+    res.status(500).json({ error: 'crypto news fetch failed', detail: String(error?.message || error) });
+  }
+});
+
+function isCryptoArticle(article) {
+  if (!article || typeof article !== 'object') return false;
+  const parts = [];
+  if (article.title) parts.push(String(article.title));
+  if (article.description) parts.push(String(article.description));
+  if (article.summary) parts.push(String(article.summary));
+  if (article.content) parts.push(String(article.content));
+  if (Array.isArray(article.category)) parts.push(article.category.join(' '));
+  if (typeof article.category === 'string') parts.push(article.category);
+  if (Array.isArray(article.keywords)) parts.push(article.keywords.join(' '));
+  if (typeof article.keywords === 'string') parts.push(article.keywords);
+  const text = parts.join(' ').toLowerCase();
+  return CRYPTO_KEYWORD_REGEX.test(text);
+}
+
+function dedupeArticles(articles = []) {
+  const seen = new Set();
+  const out = [];
+  for (const article of articles) {
+    if (!article) continue;
+    const key = (article.link || article.url || article.title || '').toLowerCase().replace(/[^a-z0-9]+/g, '');
+    if (!key) continue;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(article);
+  }
+  return out;
+}
+
+function normalizeDate(value) {
+  if (!value) return null;
+  let date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    date = new Date(`${value}Z`);
+  }
+  if (Number.isNaN(date.getTime())) return null;
+  return date.toISOString();
+}
+
+function inferCategory(article, fallback = 'Crypto') {
+  if (!article || typeof article !== 'object') return fallback;
+  const { category, topic, category_name: categoryName } = article;
+  if (Array.isArray(category) && category.length > 0) return category[0];
+  if (typeof category === 'string' && category.trim()) return category;
+  if (typeof topic === 'string' && topic.trim()) return topic;
+  if (typeof categoryName === 'string' && categoryName.trim()) return categoryName;
+  return fallback;
+}
+
+function parseKeywordsList(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.slice(0, 4).map(v => String(v));
+  if (typeof value === 'string') {
+    return value.split(/[#,\s]+/).map(v => v.trim()).filter(Boolean).slice(0, 4);
+  }
+  return [];
+}
+
+async function fetchNewsdataArticles(target = 20) {
+  const articles = [];
+  let nextPage = null;
+  let attempts = 0;
+  while (articles.length < target && attempts < 5) {
+    attempts += 1;
+    const url = new URL('https://newsdata.io/api/1/news');
+    url.searchParams.set('apikey', NEWSDATA_API_KEY);
+    url.searchParams.set('language', 'en');
+    url.searchParams.set('category', 'business,technology,top');
+    url.searchParams.set('q', '(cryptocurrency OR crypto OR bitcoin OR blockchain OR ethereum OR web3 OR defi OR nft OR token OR stablecoin)');
+    if (nextPage) url.searchParams.set('page', nextPage);
+
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 8000);
+    let response;
+    try {
+      response = await fetch(url, {
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+    } finally {
+      clearTimeout(timer);
+    }
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => '');
+      throw new Error(`newsdata HTTP ${response.status}: ${text}`);
+    }
+
+    const json = await response.json();
+    if (Array.isArray(json.results)) {
+      articles.push(...json.results);
+    }
+    nextPage = json.nextPage;
+    if (!nextPage) break;
+  }
+  return articles;
+}
+
+async function enrichArticlesWithOpenRouter(articles, limit) {
+  if (!articles.length) return [];
+  const llmInput = articles.slice(0, Math.min(articles.length, Math.max(limit + 3, 12)));
+  const payload = llmInput.map((article, idx) => ({
+    idx,
+    title: (article.title || '').slice(0, 220),
+    description: (article.description || '').slice(0, 400),
+    content: (article.content || '').slice(0, 1200),
+    source: article.source_id || article.source || '',
+    link: article.link || article.url || '',
+    pubDate: article.pubDate || article.published_at || article.date || '',
+  }));
+
+  const systemPrompt = [
+    '당신은 TWO.4를 위한 크립토 전문 뉴스 에디터입니다.',
+    '입력으로 주어지는 JSON 배열은 최신 암호화폐 뉴스를 담고 있습니다.',
+    '중복되거나 가상자산과 관련이 약한 기사, 광고성 기사는 제외하세요.',
+    `최대 ${limit}개의 핵심 기사만 남기고 정제된 정보를 제공합니다.`,
+    '각 기사는 idx(원본 인덱스), title_ko(한국어 제목), summary_ko(한국어 2~4문장 요약), summary_en(영문 1문장 요약), category(주제), keywords(최대 4개의 핵심 키워드) 필드를 포함해야 합니다.',
+    '응답은 JSON 객체 한 개로만 반환하고, 코드 블록을 사용하지 마세요.',
+  ].join(' ');
+
+  const messages = [
+    { role: 'system', content: systemPrompt },
+    { role: 'user', content: `기사 목록:\n${JSON.stringify(payload, null, 2)}` },
+  ];
+
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 15000);
+  let response;
+  try {
+    response = await fetch('https://openrouter.ai/api/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${OPENROUTER_API_KEY}`,
+        'Content-Type': 'application/json',
+        'HTTP-Referer': OPENROUTER_SITE_URL,
+        'X-Title': OPENROUTER_SITE_NAME,
+      },
+      body: JSON.stringify({
+        model: NEWS_MODEL_ID,
+        messages,
+        temperature: 0.2,
+        max_tokens: 1200,
+      }),
+      signal: controller.signal,
+    });
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    throw new Error(`OpenRouter HTTP ${response.status}: ${text}`);
+  }
+
+  const data = await response.json();
+  let content = data?.choices?.[0]?.message?.content || '';
+  content = content.trim().replace(/^```json\n?/, '').replace(/```$/, '').trim();
+
+  let parsed;
+  try {
+    parsed = JSON.parse(content);
+  } catch (err) {
+    throw new Error(`OpenRouter JSON parse error: ${err.message}`);
+  }
+
+  const rows = Array.isArray(parsed?.items) ? parsed.items : Array.isArray(parsed) ? parsed : [];
+  if (!Array.isArray(rows)) return [];
+
+  const results = [];
+  const seen = new Set();
+  for (const entry of rows) {
+    if (!entry || typeof entry.idx !== 'number') continue;
+    const original = llmInput[entry.idx];
+    if (!original) continue;
+    const dedupeKey = (original.link || original.url || original.title || '').toLowerCase();
+    if (dedupeKey && seen.has(dedupeKey)) continue;
+    seen.add(dedupeKey);
+
+    const title = entry.titleKo || entry.title_ko || entry.title || original.title || '';
+    const summaryKo = entry.summaryKo || entry.summary_ko || entry.summaryKr || entry.summary || '';
+    const summaryEn = entry.summaryEn || entry.summary_en || entry.summaryEnglish || '';
+    const keywords = parseKeywordsList(entry.keywords);
+    const category = entry.category || entry.topic || inferCategory(original);
+
+    const mapped = {
+      title,
+      originalTitle: original.title || '',
+      summary: summaryKo || summaryEn || original.description || '',
+      summaryEn: summaryEn || '',
+      originalSummary: original.description || original.content || '',
+      link: original.link || original.url || '',
+      publishedAt: normalizeDate(original.pubDate || original.published_at || original.date),
+      source: original.source_id || original.source || '',
+      category,
+      keywords,
+      imageUrl: original.image_url || original.image || null,
+      originalCategory: Array.isArray(original.category) ? original.category.join(', ') : original.category || '',
+    };
+
+    results.push(mapped);
+    if (results.length >= limit) break;
+  }
+
+  return results;
+}
+
+function mapArticlesBasic(articles, limit) {
+  return articles.slice(0, limit).map(article => ({
+    title: article.title || '',
+    originalTitle: article.title || '',
+    summary: (article.description || article.content || '').trim().slice(0, 320),
+    summaryEn: '',
+    originalSummary: article.description || article.content || '',
+    link: article.link || article.url || '',
+    publishedAt: normalizeDate(article.pubDate || article.published_at || article.date),
+    source: article.source_id || article.source || '',
+    category: inferCategory(article),
+    keywords: parseKeywordsList(article.keywords),
+    imageUrl: article.image_url || article.image || null,
+    originalCategory: Array.isArray(article.category) ? article.category.join(', ') : article.category || '',
+  }));
+}
+
 // (C) 검색 트렌드 — Google Trends RSS (KR)
 // /api/trends
 app.get('/api/trends', async (_req, res) => {


### PR DESCRIPTION
## Summary
- add a server-side `/api/crypto-news` endpoint that pulls Newsdata articles, filters for crypto topics, and uses OpenRouter to translate and summarise them in Korean
- rebuild the Echoes news page with dedicated `api.js`/`echoes.js` modules that render the translated feed dynamically and refresh headlines/status messaging
- rename the Echoes menu path to lowercase and update navigation links to match

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca4ea8f858832f86c400a115dfd00a