### PR TITLE
feat: add korean news feed and echoes client

### DIFF
--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fastifyFactory = require('fastify');
+const fastifyCors = require('@fastify/cors');
+
+function buildServer(opts = {}) {
+  const app = fastifyFactory({
+    logger: {
+      level: process.env.LOG_LEVEL || 'info',
+      ...(opts.logger || {})
+    }
+  });
+
+  app.register(fastifyCors, {
+    origin: true,
+    credentials: false
+  });
+
+  app.get('/healthz', async () => ({
+    ok: true,
+    service: 'two4-api',
+    at: new Date().toISOString()
+  }));
+
+  app.register(require('./plugins/news-ko'));
+
+  return app;
+}
+
+async function start() {
+  const server = buildServer();
+  const port = Number(process.env.PORT || process.env.API_PORT || 5000);
+  const host = process.env.HOST || '0.0.0.0';
+
+  try {
+    await server.listen({ port, host });
+    server.log.info({ port, host }, 'TWO4 API server started');
+  } catch (error) {
+    server.log.error({ err: error }, 'Failed to start TWO4 API server');
+    process.exit(1);
+  }
+}
+
+if (require.main === module) {
+  start();
+}
+
+module.exports = buildServer;

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@two4/api",
+  "version": "0.1.0",
+  "description": "Two4 Fastify API server",
+  "main": "index.js",
+  "type": "commonjs",
+  "scripts": {
+    "dev": "node --watch index.js",
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@fastify/cors": "^8.4.2",
+    "fastify": "^4.28.0"
+  }
+}

--- a/apps/api/plugins/news-ko.js
+++ b/apps/api/plugins/news-ko.js
@@ -1,0 +1,300 @@
+'use strict';
+
+const NEWS_ENDPOINT = 'https://newsdata.io/api/1/news';
+const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+const SUMMARY_ARTICLE_LIMIT = 6;
+const FETCH_TIMEOUT_MS = Number(process.env.NEWS_API_TIMEOUT_MS || 10000);
+
+function parseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return !Number.isNaN(value) && value !== 0;
+  if (typeof value === 'string') {
+    const lowered = value.trim().toLowerCase();
+    if (lowered === '') return defaultValue;
+    return ['1', 'true', 'y', 'yes', 'on'].includes(lowered);
+  }
+  return defaultValue;
+}
+
+function sanitizeText(input) {
+  if (!input) return '';
+  return String(input).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean).map((item) => String(item));
+  return [String(value)];
+}
+
+function parseDate(value) {
+  if (!value) return { iso: null, timestamp: null };
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return { iso: null, timestamp: null };
+  return { iso: date.toISOString(), timestamp: date.getTime() };
+}
+
+async function fetchJsonWithTimeout(url, { headers } = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: Object.assign({ Accept: 'application/json' }, headers || {})
+    });
+
+    const text = await response.text();
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch (error) {
+      const parseError = new Error('Failed to parse upstream JSON response');
+      parseError.cause = error;
+      parseError.body = text;
+      parseError.statusCode = 502;
+      throw parseError;
+    }
+
+    if (!response.ok) {
+      const upstreamError = new Error(`Upstream responded with status ${response.status}`);
+      upstreamError.statusCode = response.status;
+      upstreamError.body = payload || text;
+      throw upstreamError;
+    }
+
+    return payload;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      const abortError = new Error('Request to upstream provider timed out');
+      abortError.statusCode = 504;
+      throw abortError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function mapArticle(result, index) {
+  const id = result.article_id || result.link || `article-${index}`;
+  const title = sanitizeText(result.title);
+  const description = sanitizeText(result.description || result.content);
+  const { iso: publishedAt, timestamp } = parseDate(result.pubDate || result.pubDateTime || result.pubDate_tz);
+
+  return {
+    id,
+    title: title || '제목 없음',
+    description: description || '',
+    link: result.link || null,
+    source: result.source_id || (Array.isArray(result.creator) ? result.creator[0] : null),
+    categories: normalizeArray(result.category),
+    keywords: normalizeArray(result.keywords),
+    imageUrl: result.image_url || null,
+    language: result.language || 'ko',
+    country: normalizeArray(result.country),
+    rawPubDate: result.pubDate || null,
+    publishedAt,
+    publishedTimestamp: timestamp,
+    summary: null,
+    _rawForSummary: sanitizeText(result.content || result.description)
+  };
+}
+
+function pickSummaryForArticle(article, summaryMap, index) {
+  const candidates = [
+    article.id,
+    String(article.id),
+    article.title,
+    `article-${index}`,
+    String(index)
+  ].filter(Boolean);
+
+  for (const key of candidates) {
+    if (summaryMap.has(key)) {
+      return sanitizeText(summaryMap.get(key));
+    }
+  }
+  return '';
+}
+
+function parseSummaryContent(content) {
+  if (!content) return [];
+  try {
+    const direct = JSON.parse(content);
+    if (Array.isArray(direct)) return direct;
+    if (direct && Array.isArray(direct.summaries)) return direct.summaries;
+  } catch (error) {
+    const match = content.match(/\[[\s\S]*\]/);
+    if (match) {
+      try {
+        const parsed = JSON.parse(match[0]);
+        if (Array.isArray(parsed)) return parsed;
+      } catch (_) {
+        // ignore parse error from fallback attempt
+      }
+    }
+  }
+  return [];
+}
+
+async function summarizeArticles(articles, fastify) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) return;
+  if (!articles.length) return;
+
+  const subset = articles.slice(0, Math.min(SUMMARY_ARTICLE_LIMIT, articles.length));
+  const payloadForModel = subset.map((article) => ({
+    id: article.id,
+    title: article.title,
+    description: article.description,
+    content: article._rawForSummary
+  }));
+
+  const messages = [
+    {
+      role: 'system',
+      content: '당신은 데이터 저널리스트입니다. 각 한국어 기사를 두 문장 이하로 간결하게 요약하고 JSON 배열로만 응답하세요.'
+    },
+    {
+      role: 'user',
+      content: `다음 기사를 요약해 주세요. JSON 배열 형태로, 각 항목은 {"id": "기사 ID", "summary": "요약"} 구조여야 합니다.\n${JSON.stringify(payloadForModel)}`
+    }
+  ];
+
+  const body = {
+    model: process.env.OPENROUTER_MODEL || 'openrouter/auto',
+    messages,
+    temperature: 0.2,
+    max_tokens: 700
+  };
+
+  try {
+    const response = await fetch(OPENROUTER_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'HTTP-Referer': process.env.OPENROUTER_SITE_URL || 'https://two4.app',
+        'X-Title': process.env.OPENROUTER_APP_NAME || 'Two4 Echoes'
+      },
+      body: JSON.stringify(body)
+    });
+
+    const json = await response.json();
+    if (!response.ok) {
+      const error = new Error(`OpenRouter responded with status ${response.status}`);
+      error.statusCode = response.status;
+      error.body = json;
+      throw error;
+    }
+
+    const messageContent = json?.choices?.[0]?.message?.content;
+    const summaries = parseSummaryContent(messageContent);
+    if (!Array.isArray(summaries) || summaries.length === 0) {
+      fastify.log.warn({ messageContent }, 'OpenRouter did not return a parsable summary payload');
+      return;
+    }
+
+    const summaryMap = new Map();
+    for (const entry of summaries) {
+      if (!entry) continue;
+      const key = entry.id || entry.articleId || entry.title;
+      const summaryText = entry.summary || entry.synopsis || entry.text;
+      if (!key || !summaryText) continue;
+      summaryMap.set(String(key), summaryText);
+    }
+
+    subset.forEach((article, index) => {
+      const summaryText = pickSummaryForArticle(article, summaryMap, index);
+      if (summaryText) {
+        article.summary = summaryText;
+      }
+    });
+  } catch (error) {
+    fastify.log.warn({ err: error }, 'Failed to summarize articles via OpenRouter');
+  }
+}
+
+module.exports = async function newsKoPlugin(fastify) {
+  const newsApiKey = process.env.NEWSDATA_API_KEY;
+  if (!newsApiKey) {
+    fastify.log.error('NEWSDATA_API_KEY is not configured');
+  }
+
+  fastify.get('/api/news-ko', async (request, reply) => {
+    if (!newsApiKey) {
+      reply.code(500);
+      return { ok: false, error: 'NEWSDATA_API_KEY is not configured' };
+    }
+
+    const { q, category, country, page, summarize, limit } = request.query || {};
+    const perPage = Math.min(Math.max(Number(limit) || Number(process.env.NEWS_DEFAULT_LIMIT || 8), 1), 20);
+    const selectedCountry = (country || process.env.NEWS_DEFAULT_COUNTRY || 'kr').toLowerCase();
+    const url = new URL(NEWS_ENDPOINT);
+    url.searchParams.set('apikey', newsApiKey);
+    url.searchParams.set('language', 'ko');
+    if (selectedCountry) {
+      url.searchParams.set('country', selectedCountry);
+    }
+    if (q) {
+      url.searchParams.set('q', String(q));
+    }
+    if (category) {
+      url.searchParams.set('category', String(category));
+    }
+    if (page) {
+      url.searchParams.set('page', String(page));
+    }
+
+    try {
+      const upstream = await fetchJsonWithTimeout(url.toString());
+      const results = Array.isArray(upstream?.results) ? upstream.results : [];
+      const sliced = results.slice(0, perPage).map((item, index) => mapArticle(item, index));
+
+      const shouldSummarize = parseBoolean(summarize, false);
+      if (shouldSummarize) {
+        await summarizeArticles(sliced, fastify);
+      }
+
+      sliced.forEach((article) => {
+        if (!article.summary) {
+          article.summary = article.description || '';
+        }
+        delete article._rawForSummary;
+      });
+
+      const meta = {
+        fetchedAt: new Date().toISOString(),
+        totalResults: upstream?.totalResults ?? null,
+        nextPage: upstream?.nextPage || null,
+        query: {
+          q: q || null,
+          category: category || null,
+          country: selectedCountry,
+          page: page || null,
+          limit: perPage,
+          summarize: shouldSummarize && Boolean(process.env.OPENROUTER_API_KEY)
+        }
+      };
+
+      reply.header('Cache-Control', 'public, s-maxage=120, stale-while-revalidate=300');
+      return {
+        ok: true,
+        provider: 'newsdata.io',
+        meta,
+        articles: sliced
+      };
+    } catch (error) {
+      fastify.log.error({ err: error }, 'Failed to fetch Korean news');
+      const statusCode = Number.isInteger(error.statusCode) ? error.statusCode : 502;
+      reply.code(statusCode);
+      return {
+        ok: false,
+        error: 'Failed to retrieve Korean news feed',
+        detail: error.message
+      };
+    }
+  });
+};

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -821,7 +821,7 @@
       <li><a href="/menu/orbits.html">Orbits</a></li>
       <li><a href="/menu/method.html">Method</a></li>
       <li><a href="/menu/psyche.html">Psyche</a></li>
-      <li><a href="/menu/ECHOES/">Echoes</a></li>
+      <li><a href="/menu/echoes/">Echoes</a></li>
       <li><a href="/menu/constellation.html">Constellation</a></li>
       <li><a href="/menu/portal.html">Portal</a></li>
     </ul>
@@ -960,7 +960,7 @@
 </div>
 <div class="menu-section">
   <ul class="menu-items">
-    <li class="menu-item"><a href="menu/ECHOES/" class="menu-link">ECHOES (OBSERVATIONS / NEWS)<span class="korean-desc">사건의 메아리, 관찰 기록</span></a></li>
+    <li class="menu-item"><a href="menu/echoes/" class="menu-link">ECHOES (OBSERVATIONS / NEWS)<span class="korean-desc">사건의 메아리, 관찰 기록</span></a></li>
     <li class="menu-item"><a href="menu/constellation.html" class="menu-link">CONSTELLATION (COMMUNITY)<span class="korean-desc">사용자 커뮤니티</span></a></li>
     <li class="menu-item"><a href="menu/beacons.html" class="menu-link">BEACONS (ALERTS)<span class="korean-desc">주의</span></a></li>
 </ul>

--- a/apps/web/menu/echoes.html
+++ b/apps/web/menu/echoes.html
@@ -2,10 +2,10 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta http-equiv="refresh" content="0; url=ECHOES/">
+  <meta http-equiv="refresh" content="0; url=echoes/">
   <title>ECHOES | Two.4</title>
   <script>
-    window.location.replace('ECHOES/');
+    window.location.replace('echoes/');
   </script>
   <style>
     body {
@@ -24,6 +24,6 @@
   </style>
 </head>
 <body>
-  <p>Redirecting to <a href="ECHOES/">ECHOES (OBSERVATIONS / NEWS)</a>…</p>
+  <p>Redirecting to <a href="echoes/">ECHOES (OBSERVATIONS / NEWS)</a>…</p>
 </body>
 </html>

--- a/apps/web/menu/echoes/echoes.js
+++ b/apps/web/menu/echoes/echoes.js
@@ -1,0 +1,248 @@
+(() => {
+  const API_ENDPOINT = '/api/news-ko';
+  const grid = document.getElementById('newsGrid');
+  const headlines = document.querySelector('.headlines');
+  const sectionTitle = document.querySelector('.section-title');
+
+  function toBoolean(value) {
+    if (typeof value === 'boolean') return value;
+    if (typeof value === 'number') return !Number.isNaN(value) && value !== 0;
+    if (typeof value === 'string') {
+      const lowered = value.trim().toLowerCase();
+      return ['1', 'true', 'yes', 'y', 'on'].includes(lowered);
+    }
+    return false;
+  }
+
+  function formatRelativeTime(input) {
+    if (!input) return '방금 전';
+    const date = typeof input === 'number' ? new Date(input) : new Date(String(input));
+    if (Number.isNaN(date.getTime())) return '방금 전';
+
+    const diffMs = Date.now() - date.getTime();
+    if (diffMs <= 0) return '방금 전';
+
+    const minutes = Math.round(diffMs / 60000);
+    if (minutes < 1) return '방금 전';
+    if (minutes < 60) return `${minutes}분 전`;
+
+    const hours = Math.round(minutes / 60);
+    if (hours < 24) return `${hours}시간 전`;
+
+    const days = Math.round(hours / 24);
+    if (days < 7) return `${days}일 전`;
+
+    return date.toLocaleDateString('ko-KR', {
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  function renderLoading() {
+    if (!grid) return;
+    grid.innerHTML = '';
+    const loading = document.createElement('p');
+    loading.className = 'news-empty';
+    loading.textContent = '뉴스를 불러오는 중입니다…';
+    grid.appendChild(loading);
+  }
+
+  function renderError(message) {
+    if (!grid) return;
+    grid.innerHTML = '';
+    const errorEl = document.createElement('p');
+    errorEl.className = 'news-empty news-error';
+    errorEl.textContent = message;
+    grid.appendChild(errorEl);
+  }
+
+  function ensureArray(value) {
+    if (Array.isArray(value)) return value;
+    if (!value) return [];
+    return [value];
+  }
+
+  function createNewsCard(article) {
+    const card = document.createElement('article');
+    card.className = 'news-card';
+
+    const content = document.createElement('div');
+    content.className = 'news-content';
+
+    const meta = document.createElement('div');
+    meta.className = 'news-meta';
+
+    const category = document.createElement('span');
+    category.className = 'news-category';
+    const categories = ensureArray(article.categories);
+    const categoryLabel = categories[0] || (article.source && String(article.source).toUpperCase()) || '뉴스';
+    category.textContent = categoryLabel;
+
+    const time = document.createElement('span');
+    time.className = 'news-time';
+    time.textContent = formatRelativeTime(article.publishedAt || article.pubDate || article.publishedTimestamp);
+
+    meta.appendChild(category);
+    meta.appendChild(time);
+
+    const title = document.createElement('h3');
+    title.className = 'news-title';
+    title.textContent = article.title || '제목을 불러오지 못했습니다';
+
+    const summary = document.createElement('p');
+    summary.className = 'news-summary';
+    summary.textContent = article.summary || article.description || '요약을 불러오지 못했습니다. 원문을 확인해 주세요.';
+
+    const link = document.createElement('a');
+    link.className = 'news-link';
+    if (article.link) {
+      link.href = article.link;
+      link.target = '_blank';
+      link.rel = 'noopener noreferrer';
+    } else {
+      link.href = '#';
+      link.setAttribute('aria-disabled', 'true');
+    }
+    link.textContent = '기사 원문';
+
+    content.appendChild(meta);
+    content.appendChild(title);
+    content.appendChild(summary);
+    content.appendChild(link);
+
+    const imageWrapper = document.createElement('div');
+    imageWrapper.className = 'news-image';
+    if (article.imageUrl) {
+      const img = document.createElement('img');
+      img.loading = 'lazy';
+      img.src = article.imageUrl;
+      img.alt = article.title ? `${article.title} 관련 이미지` : '뉴스 이미지';
+      imageWrapper.appendChild(img);
+    }
+
+    card.appendChild(content);
+    card.appendChild(imageWrapper);
+
+    return card;
+  }
+
+  function renderArticles(articles) {
+    if (!grid) return;
+    grid.innerHTML = '';
+
+    if (!articles || articles.length === 0) {
+      const empty = document.createElement('p');
+      empty.className = 'news-empty';
+      empty.textContent = '표시할 한국어 뉴스를 찾지 못했습니다.';
+      grid.appendChild(empty);
+      return;
+    }
+
+    const fragment = document.createDocumentFragment();
+    articles.forEach((article) => {
+      fragment.appendChild(createNewsCard(article));
+    });
+    grid.appendChild(fragment);
+
+    if (typeof window.initializeNewsCards === 'function') {
+      window.initializeNewsCards();
+    }
+  }
+
+  function updateHeadlines(articles) {
+    if (!headlines) return;
+    headlines.innerHTML = '';
+
+    const picks = (articles || []).slice(0, 3);
+    if (picks.length === 0) {
+      const emptyItem = document.createElement('div');
+      emptyItem.className = 'headline-item';
+      emptyItem.textContent = '헤드라인을 불러오지 못했습니다.';
+      headlines.appendChild(emptyItem);
+      return;
+    }
+
+    picks.forEach((article) => {
+      const item = document.createElement('div');
+      item.className = 'headline-item';
+
+      const category = document.createElement('div');
+      category.className = 'headline-category';
+      const categories = ensureArray(article.categories);
+      category.textContent = categories[0] || (article.source && String(article.source).toUpperCase()) || '뉴스';
+
+      const title = document.createElement('div');
+      title.className = 'headline-title';
+      title.textContent = article.title || '제목을 불러오지 못했습니다';
+
+      const time = document.createElement('div');
+      time.className = 'headline-time';
+      time.textContent = formatRelativeTime(article.publishedAt || article.pubDate || article.publishedTimestamp);
+
+      item.appendChild(category);
+      item.appendChild(title);
+      item.appendChild(time);
+      headlines.appendChild(item);
+    });
+  }
+
+  function updateSectionTitle(meta) {
+    if (!sectionTitle || !meta) return;
+    if (!meta.fetchedAt) return;
+
+    const fetchedDate = new Date(meta.fetchedAt);
+    if (Number.isNaN(fetchedDate.getTime())) return;
+
+    const baseText = 'Intelligence Feed';
+    const formatted = fetchedDate.toLocaleTimeString('ko-KR', {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
+    sectionTitle.textContent = `${baseText} · ${formatted} 업데이트`;
+  }
+
+  async function loadNews() {
+    if (!grid) return;
+
+    renderLoading();
+
+    const params = new URLSearchParams();
+    params.set('summarize', '1');
+    params.set('country', 'kr');
+    params.set('limit', '8');
+
+    try {
+      const response = await fetch(`${API_ENDPOINT}?${params.toString()}`, {
+        headers: {
+          Accept: 'application/json'
+        }
+      });
+
+      if (!response.ok) {
+        throw new Error(`Unexpected status ${response.status}`);
+      }
+
+      const payload = await response.json();
+      const articles = Array.isArray(payload.articles) ? payload.articles : [];
+
+      renderArticles(articles);
+      updateHeadlines(articles);
+      updateSectionTitle(payload.meta || payload);
+    } catch (error) {
+      console.error('Failed to load /api/news-ko', error);
+      renderError('실시간 뉴스를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const autoRefresh = toBoolean(grid && grid.dataset.autorefresh);
+    loadNews();
+
+    if (autoRefresh) {
+      const interval = Number(grid.dataset.refreshInterval || 300000);
+      if (!Number.isNaN(interval) && interval > 0) {
+        setInterval(loadNews, interval);
+      }
+    }
+  });
+})();

--- a/apps/web/menu/echoes/index.html
+++ b/apps/web/menu/echoes/index.html
@@ -509,6 +509,24 @@
             display: grid;
             gap: 20px;
         }
+
+        .news-empty {
+            grid-column: 1 / -1;
+            text-align: center;
+            padding: 2.5rem 1.5rem;
+            border: 1px dashed var(--border-color);
+            border-radius: 16px;
+            color: var(--text-secondary);
+            background: rgba(18, 18, 35, 0.6);
+            font-size: 0.95rem;
+            letter-spacing: 0.01em;
+        }
+
+        .news-error {
+            border-style: solid;
+            color: #ff9c9c;
+            background: rgba(255, 70, 70, 0.08);
+        }
         
         .news-card {
             background: var(--card-bg);
@@ -859,7 +877,7 @@
                     <li><a href="/menu/orbits.html" data-tooltip="지표, 신호">Orbits</a></li>
                     <li><a href="/menu/method.html" data-tooltip="기법">Method</a></li>
                     <li><a href="/menu/psyche.html" data-tooltip="심법">Psyche</a></li>
-                    <li><a href="/menu/ECHOES/" class="active" data-tooltip="뉴스, 관찰기록">Echoes</a></li>
+                    <li><a href="/menu/echoes/" class="active" data-tooltip="뉴스, 관찰기록">Echoes</a></li>
                     <li><a href="/menu/constellation.html" data-tooltip="커뮤니티">Constellation</a></li>
                     <li><a href="/menu/portal.html" data-tooltip="로그인/로그아웃">Portal</a></li>
                 </ul>
@@ -1202,5 +1220,6 @@
             setInterval(updatePrices, 10000);
         });
     </script>
+    <script defer src="/menu/echoes/echoes.js"></script>
 </body>
 </html>

--- a/apps/web/menu/header.html
+++ b/apps/web/menu/header.html
@@ -84,7 +84,7 @@
       <li><a href="/menu/orbits.html">Orbits</a></li>
       <li><a href="/menu/method.html">Method</a></li>
       <li><a href="/menu/psyche.html">Psyche</a></li>
-      <li><a href="/menu/ECHOES/">Echoes</a></li>
+      <li><a href="/menu/echoes/">Echoes</a></li>
       <li><a href="/menu/constellation.html">Constellation</a></li>
       <li><a href="/menu/portal.html">Portal</a></li>
     </ul>
@@ -121,7 +121,7 @@
     <li><a href="orbits.html">ORBITS (INDICATORS)</a></li>
     <li><a href="method.html">METHOD (TECHNIQUE)</a></li>
     <li><a href="psyche.html">PSYCHE</a></li>
-    <li><a href="ECHOES/">ECHOES (NEWS)</a></li>
+    <li><a href="echoes/">ECHOES (NEWS)</a></li>
     <li><a href="constellation.html">CONSTELLATION</a></li>
     <li><a href="beacons.html">BEACONS</a></li>
     <li><a href="portal.html">PORTAL</a></li>


### PR DESCRIPTION
## Summary
- add a Fastify server entry that wires up a new /api/news-ko plugin
- implement the news-ko plugin to fetch Newsdata.io articles, optionally summarize them via OpenRouter, and serve structured JSON
- rename the Echoes menu path to lowercase and load a new frontend script that renders live news cards with loading/error states

## Testing
- npm install *(fails: registry returned 403 for @fastify/cors)*

------
https://chatgpt.com/codex/tasks/task_e_68ca56a94290832f9ead4f9240cf3994