### PR TITLE
Refactor Korean news route into dedicated router

### DIFF
--- a/routes/news-ko.js
+++ b/routes/news-ko.js
@@ -1,0 +1,360 @@
+const express = require('express');
+
+const NEWS_ENDPOINT = 'https://newsdata.io/api/1/news';
+const OPENROUTER_ENDPOINT = 'https://openrouter.ai/api/v1/chat/completions';
+const SUMMARY_ARTICLE_LIMIT = 6;
+const FETCH_TIMEOUT_MS = Number(process.env.NEWS_API_TIMEOUT_MS || 10000);
+const DEFAULT_CACHE_TTL_MS = Number(process.env.NEWS_CACHE_TTL_MS || 120000);
+
+function defaultParseBoolean(value, defaultValue = false) {
+  if (value === undefined || value === null) return defaultValue;
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'number') return !Number.isNaN(value) && value !== 0;
+  if (typeof value === 'string') {
+    const lowered = value.trim().toLowerCase();
+    if (lowered === '') return defaultValue;
+    return ['1', 'true', 'y', 'yes', 'on'].includes(lowered);
+  }
+  return defaultValue;
+}
+
+function sanitizeText(input) {
+  if (!input) return '';
+  return String(input).replace(/\s+/g, ' ').trim();
+}
+
+function normalizeArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean).map((item) => String(item));
+  return [String(value)];
+}
+
+function parseDate(value) {
+  if (!value) return { iso: null, timestamp: null };
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return { iso: null, timestamp: null };
+  return { iso: date.toISOString(), timestamp: date.getTime() };
+}
+
+async function fetchJsonWithTimeout(url, { headers } = {}) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: Object.assign({ Accept: 'application/json' }, headers || {})
+    });
+
+    const text = await response.text();
+    let payload;
+    try {
+      payload = text ? JSON.parse(text) : null;
+    } catch (error) {
+      const parseError = new Error('Failed to parse upstream JSON response');
+      parseError.cause = error;
+      parseError.body = text;
+      parseError.statusCode = 502;
+      throw parseError;
+    }
+
+    if (!response.ok) {
+      const upstreamError = new Error(`Upstream responded with status ${response.status}`);
+      upstreamError.statusCode = response.status;
+      upstreamError.body = payload || text;
+      throw upstreamError;
+    }
+
+    return payload;
+  } catch (error) {
+    if (error.name === 'AbortError') {
+      const abortError = new Error('Request to upstream provider timed out');
+      abortError.statusCode = 504;
+      throw abortError;
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function mapArticle(result, index) {
+  const id = result.article_id || result.link || `article-${index}`;
+  const title = sanitizeText(result.title);
+  const description = sanitizeText(result.description || result.content);
+  const { iso: publishedAt, timestamp } = parseDate(result.pubDate || result.pubDateTime || result.pubDate_tz);
+
+  return {
+    id,
+    title: title || '제목 없음',
+    description: description || '',
+    link: result.link || null,
+    source: result.source_id || (Array.isArray(result.creator) ? result.creator[0] : null),
+    categories: normalizeArray(result.category),
+    keywords: normalizeArray(result.keywords),
+    imageUrl: result.image_url || null,
+    language: result.language || 'ko',
+    country: normalizeArray(result.country),
+    rawPubDate: result.pubDate || null,
+    publishedAt,
+    publishedTimestamp: timestamp,
+    summary: null,
+    _rawForSummary: sanitizeText(result.content || result.description)
+  };
+}
+
+function pickSummaryForArticle(article, summaryMap, index) {
+  const candidates = [
+    article.id,
+    String(article.id),
+    article.title,
+    `article-${index}`,
+    String(index)
+  ].filter(Boolean);
+
+  for (const key of candidates) {
+    if (summaryMap.has(key)) {
+      return sanitizeText(summaryMap.get(key));
+    }
+  }
+  return '';
+}
+
+function parseSummaryContent(content) {
+  if (!content) return [];
+  try {
+    const direct = JSON.parse(content);
+    if (Array.isArray(direct)) return direct;
+    if (direct && Array.isArray(direct.summaries)) return direct.summaries;
+  } catch (error) {
+    const match = content.match(/\[[\s\S]*\]/);
+    if (match) {
+      try {
+        const parsed = JSON.parse(match[0]);
+        if (Array.isArray(parsed)) return parsed;
+      } catch (_) {
+        // ignore parse error from fallback attempt
+      }
+    }
+  }
+  return [];
+}
+
+async function summarizeArticles(articles, logger) {
+  const apiKey = process.env.OPENROUTER_API_KEY;
+  if (!apiKey) return;
+  if (!articles.length) return;
+
+  const subset = articles.slice(0, Math.min(SUMMARY_ARTICLE_LIMIT, articles.length));
+  const payloadForModel = subset.map((article) => ({
+    id: article.id,
+    title: article.title,
+    description: article.description,
+    content: article._rawForSummary
+  }));
+
+  const messages = [
+    {
+      role: 'system',
+      content: '당신은 데이터 저널리스트입니다. 각 한국어 기사를 두 문장 이하로 간결하게 요약하고 JSON 배열로만 응답하세요.'
+    },
+    {
+      role: 'user',
+      content: `다음 기사를 요약해 주세요. JSON 배열 형태로, 각 항목은 {"id": "기사 ID", "summary": "요약"} 구조여야 합니다.\n${JSON.stringify(payloadForModel)}`
+    }
+  ];
+
+  const body = {
+    model: process.env.OPENROUTER_MODEL || 'openrouter/auto',
+    messages,
+    temperature: 0.2,
+    max_tokens: 700
+  };
+
+  try {
+    const response = await fetch(OPENROUTER_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+        'HTTP-Referer': process.env.OPENROUTER_SITE_URL || 'https://two4.app',
+        'X-Title': process.env.OPENROUTER_APP_NAME || 'Two4 Echoes'
+      },
+      body: JSON.stringify(body)
+    });
+
+    const json = await response.json();
+    if (!response.ok) {
+      const error = new Error(`OpenRouter responded with status ${response.status}`);
+      error.statusCode = response.status;
+      error.body = json;
+      throw error;
+    }
+
+    const messageContent = json?.choices?.[0]?.message?.content;
+    const summaries = parseSummaryContent(messageContent);
+    if (!Array.isArray(summaries) || summaries.length === 0) {
+      logger?.warn?.({ messageContent }, 'OpenRouter did not return a parsable summary payload');
+      return;
+    }
+
+    const summaryMap = new Map();
+    for (const entry of summaries) {
+      if (!entry) continue;
+      const key = entry.id || entry.articleId || entry.title;
+      const summaryText = entry.summary || entry.synopsis || entry.text;
+      if (!key || !summaryText) continue;
+      summaryMap.set(String(key), summaryText);
+    }
+
+    subset.forEach((article, index) => {
+      const summaryText = pickSummaryForArticle(article, summaryMap, index);
+      if (summaryText) {
+        article.summary = summaryText;
+      }
+    });
+  } catch (error) {
+    logger?.warn?.({ err: error }, 'Failed to summarize articles via OpenRouter');
+  }
+}
+
+function createCacheHelpers(ttlMs = DEFAULT_CACHE_TTL_MS) {
+  const store = new Map();
+  const hit = (key) => {
+    const entry = store.get(key);
+    if (!entry) return null;
+    if (Date.now() - entry.t > ttlMs) {
+      store.delete(key);
+      return null;
+    }
+    return entry;
+  };
+  const keep = (key, payload) => {
+    if (!payload || payload.ok === false) return;
+    store.set(key, { ...payload, t: Date.now() });
+  };
+  return { hit, keep };
+}
+
+function createNewsKoRouter({
+  hit,
+  keep,
+  parseBoolean = defaultParseBoolean,
+  setCorsAndCache,
+  cacheTtlMs = DEFAULT_CACHE_TTL_MS,
+  logger = console
+} = {}) {
+  const router = express.Router();
+  const cacheHelpers = createCacheHelpers(cacheTtlMs);
+  const hitFn = typeof hit === 'function' ? hit : cacheHelpers.hit;
+  const keepFn = typeof keep === 'function' ? keep : cacheHelpers.keep;
+  const newsApiKey = process.env.NEWSDATA_API_KEY;
+
+  router.get('/', async (req, res) => {
+    if (!newsApiKey) {
+      const body = { ok: false, error: 'NEWSDATA_API_KEY is not configured' };
+      if (typeof setCorsAndCache === 'function') setCorsAndCache(res);
+      res.status(500).json(body);
+      return;
+    }
+
+    const { q, category, country, page, summarize, limit } = req.query || {};
+    const perPage = Math.min(Math.max(Number(limit) || Number(process.env.NEWS_DEFAULT_LIMIT || 8), 1), 20);
+    const selectedCountry = (country || process.env.NEWS_DEFAULT_COUNTRY || 'kr').toLowerCase();
+    const url = new URL(NEWS_ENDPOINT);
+    url.searchParams.set('apikey', newsApiKey);
+    url.searchParams.set('language', 'ko');
+    if (selectedCountry) {
+      url.searchParams.set('country', selectedCountry);
+    }
+    if (q) {
+      url.searchParams.set('q', String(q));
+    }
+    if (category) {
+      url.searchParams.set('category', String(category));
+    }
+    if (page) {
+      url.searchParams.set('page', String(page));
+    }
+
+    const shouldSummarize = parseBoolean(summarize, false) && Boolean(process.env.OPENROUTER_API_KEY);
+    const cacheKey = `NEWSKO:${JSON.stringify({ q: q || null, category: category || null, country: selectedCountry, page: page || null, limit: perPage, summarize: shouldSummarize })}`;
+
+    const cached = hitFn(cacheKey);
+    if (cached && cached.body) {
+      if (typeof setCorsAndCache === 'function') setCorsAndCache(res);
+      res.setHeader('Cache-Control', 'public, s-maxage=120, stale-while-revalidate=300');
+      res.type(cached.ct || 'application/json');
+      res.status(cached.status || 200).send(cached.body);
+      return;
+    }
+
+    try {
+      const upstream = await fetchJsonWithTimeout(url.toString());
+      const results = Array.isArray(upstream?.results) ? upstream.results : [];
+      const sliced = results.slice(0, perPage).map((item, index) => mapArticle(item, index));
+
+      if (shouldSummarize) {
+        await summarizeArticles(sliced, logger);
+      }
+
+      sliced.forEach((article) => {
+        if (!article.summary) {
+          article.summary = article.description || '';
+        }
+        delete article._rawForSummary;
+      });
+
+      const meta = {
+        fetchedAt: new Date().toISOString(),
+        totalResults: upstream?.totalResults ?? null,
+        nextPage: upstream?.nextPage || null,
+        query: {
+          q: q || null,
+          category: category || null,
+          country: selectedCountry,
+          page: page || null,
+          limit: perPage,
+          summarize: shouldSummarize
+        }
+      };
+
+      const payload = {
+        ok: true,
+        provider: 'newsdata.io',
+        meta,
+        articles: sliced
+      };
+
+      const body = JSON.stringify(payload);
+      if (typeof setCorsAndCache === 'function') setCorsAndCache(res);
+      res.setHeader('Cache-Control', 'public, s-maxage=120, stale-while-revalidate=300');
+      res.type('application/json').status(200).send(body);
+      keepFn(cacheKey, { ok: true, status: 200, body, ct: 'application/json; charset=utf-8' });
+    } catch (error) {
+      logger?.error?.({ err: error }, 'Failed to fetch Korean news');
+      const statusCode = Number.isInteger(error.statusCode) ? error.statusCode : 502;
+      const body = {
+        ok: false,
+        error: 'Failed to retrieve Korean news feed',
+        detail: error.message
+      };
+      if (typeof setCorsAndCache === 'function') setCorsAndCache(res);
+      res.status(statusCode).json(body);
+    }
+  });
+
+  return router;
+}
+
+module.exports = createNewsKoRouter;
+module.exports.parseBoolean = defaultParseBoolean;
+module.exports.fetchJsonWithTimeout = fetchJsonWithTimeout;
+module.exports.helpers = {
+  sanitizeText,
+  normalizeArray,
+  parseDate,
+  mapArticle,
+  pickSummaryForArticle,
+  parseSummaryContent
+};

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const fs = require('fs');
 const mongoose = require('mongoose');
 const Parser = require('rss-parser');               // RSS (네이버/구글 트렌드)
 const parser = new Parser();
+const createNewsKoRouter = require('./routes/news-ko');
 
 const app = express();
 const PORT = process.env.COSMOS_PORT || process.env.PORT || 3000;
@@ -51,6 +52,9 @@ const cache = new Map();
 const TTL_MS = 60_000;
 const hit  = key => { const v = cache.get(key); return v && (Date.now() - v.t < TTL_MS) ? v : null; };
 const keep = (key, payload) => { if (payload.ok) cache.set(key, { ...payload, t: Date.now() }); };
+
+const newsKoRouter = createNewsKoRouter({ hit, keep, setCorsAndCache });
+app.use('/api/news-ko', newsKoRouter);
 
 // === ADD: TTL-override hit() & limited concurrency map ===
 const hit2 = (key, ttlMs) => {


### PR DESCRIPTION
## Summary
- move the Korean news endpoint implementation into routes/news-ko.js with reusable helpers and caching
- mount the extracted router from server.js so it continues to share the global cache utilities

## Testing
- MONGODB_URI=mongodb://127.0.0.1:27017/test npm start *(fails: connect ECONNREFUSED 127.0.0.1:27017)*

------
https://chatgpt.com/codex/tasks/task_e_68ca60f5ef74832fb633c9c8e9605321