### PR TITLE
Adjust COSMOS table symbol display and typography

### DIFF
--- a/apps/web/menu/cosmos/cosmos.js
+++ b/apps/web/menu/cosmos/cosmos.js
@@ -24,6 +24,13 @@ const fmtPct =n=>{
   return `<span class="pct ${s}">${t}</span>`;
 };
 
+const escapeHtml = str => String(str ?? '')
+  .replace(/&/g, '&amp;')
+  .replace(/</g, '&lt;')
+  .replace(/>/g, '&gt;')
+  .replace(/"/g, '&quot;')
+  .replace(/'/g, '&#39;');
+
 /* ---- 안전 fetch helper ---- */
 async function safeJson(url){
   try{
@@ -506,7 +513,13 @@ function rowHTML(c, i){
   const p24 = c.price_change_percentage_24h_in_currency ?? c.price_change_percentage_24h;
   const p7d = c.price_change_percentage_7d_in_currency ?? c.price_change_percentage_7d;
 
-  const sym  = (c.symbol || '').toUpperCase();      // 예: BTC
+  const rawSymbol = (c.symbol || '').trim();
+  const sym  = rawSymbol.toUpperCase();      // 예: BTC
+  const isUrlSymbol = /^https?:\/\//i.test(rawSymbol) || (rawSymbol.includes('.') && rawSymbol.length > 6);
+  const displaySymbol = isUrlSymbol ? rawSymbol : sym;
+  const symbolBoxClass = `symbol-box${isUrlSymbol ? ' long' : ''}`;
+  const symbolNameClass = `symbol-name${isUrlSymbol ? ' long' : ''}`;
+  const safeSymbol = escapeHtml(displaySymbol);
   const displayName = (c.name && c.name.toUpperCase() !== sym) ? c.name : nameFor(sym);
   const pair = sym ? sym + 'USDT' : '';             // 예: BTCUSDT
 
@@ -516,7 +529,7 @@ function rowHTML(c, i){
     <td class="sticky-name">
       <div class="mkt-name">
         <img src="/api/icon/${(c.symbol||'').toLowerCase()}" alt="${(c.symbol||'').toUpperCase()}">
-        <div class="symbol-box"><span class="symbol-name">${sym}</span></div>
+        <div class="${symbolBoxClass}"><span class="${symbolNameClass}" title="${safeSymbol}">${safeSymbol}</span></div>
         <span class="full">${displayName}</span>
       </div>
     </td>

--- a/apps/web/menu/cosmos/index.html
+++ b/apps/web/menu/cosmos/index.html
@@ -52,7 +52,7 @@
       background: linear-gradient(135deg, #0a0e1a 0%, #1a0f2e 50%, #0f1729 100%);
       color: var(--text-primary);
       font-family: 'Rajdhani', sans-serif;
-      font-size: 16px;
+      font-size: 14px;
       font-weight: 400;
       min-height: 100vh;
       position: relative;
@@ -371,9 +371,9 @@
       border: 1px solid var(--glass-border);
       color: var(--text-primary);
       border-radius: 12px;
-      padding: 12px 20px;
+      padding: 10px 18px;
       font-family: 'Rajdhani', sans-serif;
-      font-size: 16px;
+      font-size: 14px;
       font-weight: 500;
       outline: none;
       transition: all 0.3s ease;
@@ -446,7 +446,7 @@
     
     /* Table cells with glass effect */
     #mkt tbody td {
-      padding: 16px;
+      padding: 12px 14px;
       vertical-align: middle;
       background: linear-gradient(135deg, rgba(0, 255, 255, 0.03), rgba(153, 69, 255, 0.03));
       backdrop-filter: blur(10px);
@@ -506,7 +506,7 @@
     }
     
     .mkt-name .symbol-box {
-     max-width: 5.5ch;
+      max-width: 5.5ch;
       overflow: hidden;
       white-space: nowrap;
       text-align: left;
@@ -515,10 +515,17 @@
       padding: 0 2px;
     }
 
+    .mkt-name .symbol-box.long {
+      flex: 0 1 180px;
+      max-width: 180px;
+      white-space: normal;
+      overflow: visible;
+    }
+
     .mkt-name .symbol-name {
       font-family: 'Orbitron', monospace;
       font-weight: 700;
-      font-size: clamp(12px, 3.5vw, 0.95rem);
+      font-size: clamp(11px, 3vw, 0.85rem);
       letter-spacing: -0.5px;
       color: var(--neon-cyan);
       text-shadow: 0 0 8px currentColor;
@@ -528,17 +535,27 @@
             overflow: hidden;
       text-overflow: ellipsis;
     }
-    
+
+    .mkt-name .symbol-name.long {
+      white-space: normal;
+      word-break: break-all;
+      text-overflow: unset;
+      font-size: clamp(10px, 2.6vw, 0.75rem);
+      letter-spacing: 0;
+      line-height: 1.2;
+    }
+
     .mkt-name .full {
       opacity: 0.7;
       font-weight: 400;
+      font-size: clamp(11px, 2.8vw, 0.82rem);
     }
-    
+
     .num {
       text-align: right;
       font-variant-numeric: tabular-nums;
       font-weight: 600;
-      font-size: 15px;
+      font-size: 14px;
     }
     
     .pct.up {
@@ -725,16 +742,24 @@
       .mkt-name {
         gap: 8px;
       }
-      
+
       .mkt-name img {
         width: 24px;
         height: 24px;
       }
-      
-      .mkt-name .symbol-text {
-        font-size: 13px;
+
+      .mkt-name .symbol-box.long {
+        max-width: 60vw;
       }
       
+      .mkt-name .symbol-name {
+        font-size: 13px;
+      }
+
+      .mkt-name .symbol-name.long {
+        font-size: 11px;
+      }
+
       .mkt-name .full {
         display: none;
       }
@@ -791,8 +816,12 @@
         min-width: 500px;
       }
 
-      .mkt-name .symbol-text {
+      .mkt-name .symbol-name {
         font-size: 12px;
+      }
+
+      .mkt-name .symbol-box.long {
+        max-width: 70vw;
       }
       
       /* Mobile: show only essential columns */


### PR DESCRIPTION
## Summary
- allow URL-style symbols in the COSMOS market table to expand and display fully with safe HTML escaping
- tune responsive styles to shrink typography and spacing for denser data presentation across viewports

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbdee003b4832f8fc58b85e65ed862