### PR TITLE
Cache Cosmos market icons in S3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,7 @@ OPENROUTER_API_KEY=your_openrouter_api_key_here
 MONGODB_URI=your_mongodb_connection_string
 
 # === AWS Storage ===
+AWS_STORAGE=
 AWS_ACCESS_KEY_ID=your_access_key_id
 AWS_SECRET_ACCESS_KEY=your_secret_access_key
 AWS_BUCKET_NAME=two4-storage-seoul

--- a/apps/config/vars.js
+++ b/apps/config/vars.js
@@ -3,6 +3,7 @@ export const CONFIG = {
   modelId: process.env.MODEL_ID,
 
   aws: {
+    storage: process.env.AWS_STORAGE,
     accessKeyId: process.env.AWS_ACCESS_KEY_ID,
     secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
     bucketName: process.env.AWS_BUCKET_NAME,

--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
     "start": "node server.js"
   },
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.614.0",
     "express": "^4.18.2",
     "cookie-parser": "^1.4.6",
     "node-fetch": "^2.6.9",
     "mongoose": "^8.6.0",
-    "rss-parser": "^3.12.0"
+    "rss-parser": "^3.12.0",
+    "sharp": "^0.33.4"
   },
   "engines": {
     "node": "18.x"

--- a/server.js
+++ b/server.js
@@ -3,7 +3,10 @@ const express = require('express');
 const path = require('path');
 const fs = require('fs');
 const mongoose = require('mongoose');
+const crypto = require('crypto');
 const Parser = require('rss-parser');               // RSS (네이버/구글 트렌드)
+const { S3Client, GetObjectCommand, PutObjectCommand } = require('@aws-sdk/client-s3');
+const sharp = require('sharp');
 const parser = new Parser();
 const createNewsKoRouter = require('./routes/news-ko');
 
@@ -22,6 +25,180 @@ app.use('/icons', express.static(ICON_DIR, {
   }
 }));
 const FALLBACK_ICON = '/media/coin.svg';
+
+const AWS_BUCKET_NAME = process.env.AWS_BUCKET_NAME || '';
+const AWS_REGION = process.env.AWS_REGION || '';
+const AWS_ACCESS_KEY_ID = process.env.AWS_ACCESS_KEY_ID || '';
+const AWS_SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || '';
+const AWS_STORAGE_PREFIX = (process.env.AWS_STORAGE || '')
+  .replace(/^[a-z]+:\/\//i, '')
+  .replace(/^\/+|\/+$|\s+/g, '');
+
+const ICON_S3_CACHE_CONTROL = 'public, max-age=31536000, immutable';
+const ICON_OUTPUT_TYPE = 'image/webp';
+const ICON_SIZE = 128;
+
+let s3Client = null;
+const iconInFlight = new Map();
+
+function hasS3Support() {
+  return Boolean(AWS_BUCKET_NAME && AWS_REGION);
+}
+
+function getS3Client() {
+  if (!hasS3Support()) return null;
+  if (!s3Client) {
+    const base = { region: AWS_REGION };
+    if (AWS_ACCESS_KEY_ID && AWS_SECRET_ACCESS_KEY) {
+      base.credentials = {
+        accessKeyId: AWS_ACCESS_KEY_ID,
+        secretAccessKey: AWS_SECRET_ACCESS_KEY,
+      };
+    }
+    s3Client = new S3Client(base);
+  }
+  return s3Client;
+}
+
+function buildIconKey(symbol) {
+  const normalized = (symbol || '').toLowerCase();
+  const safe = normalized.replace(/[^a-z0-9._-]/g, '-');
+  const hash = crypto.createHash('md5').update(normalized).digest('hex').slice(0, 10);
+  const baseName = `${safe || 'coin'}-${hash}.webp`;
+  const parts = [AWS_STORAGE_PREFIX, 'icons', 'cosmos', baseName].filter(Boolean);
+  return parts.join('/');
+}
+
+async function readBodyBuffer(body) {
+  if (!body) return null;
+  if (typeof body.transformToByteArray === 'function') {
+    const arr = await body.transformToByteArray();
+    return Buffer.from(arr);
+  }
+  const chunks = [];
+  for await (const chunk of body) chunks.push(Buffer.from(chunk));
+  return Buffer.concat(chunks);
+}
+
+async function trySendS3Icon(res, key) {
+  const client = getS3Client();
+  if (!client) return false;
+  try {
+    const data = await client.send(new GetObjectCommand({ Bucket: AWS_BUCKET_NAME, Key: key }));
+    const buffer = await readBodyBuffer(data.Body);
+    if (!buffer) return false;
+
+    res.type(data.ContentType || ICON_OUTPUT_TYPE);
+    res.setHeader('Cache-Control', data.CacheControl || 'public, max-age=86400');
+    res.setHeader('Content-Length', String(buffer.length));
+    res.send(buffer);
+    return true;
+  } catch (err) {
+    const status = err?.$metadata?.httpStatusCode;
+    if (err?.name === 'NoSuchKey' || status === 404) return false;
+    if (err?.Code === 'NoSuchKey') return false;
+    console.error('S3 icon fetch error:', err?.message || err);
+    return false;
+  }
+}
+
+async function resolveCoinImageUrl(symbol) {
+  const key = `ICON_URL:${(symbol || '').toUpperCase()}`;
+  const cached = hit2(key, 7 * 24 * 60 * 60 * 1000);
+  if (cached && typeof cached.body === 'string') return cached.body;
+
+  const url = `https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(symbol || '')}`;
+  const payload = await proxyFetch(url, { 'User-Agent': 'two4-cosmos/1.0' });
+  if (!payload.ok) return null;
+
+  try {
+    const json = JSON.parse(payload.body || '{}');
+    const coins = Array.isArray(json.coins) ? json.coins : [];
+    const match = coins.find(c => (c.symbol || '').toLowerCase() === String(symbol || '').toLowerCase());
+    const img = match?.thumb || match?.large || match?.small || null;
+    if (img) {
+      keep(key, { ok: true, body: img, ct: 'text/plain' });
+      return img;
+    }
+  } catch (e) {
+    console.error('Coin image parse error:', e);
+  }
+  return null;
+}
+
+async function downloadImageBuffer(url) {
+  if (!url) return null;
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(), 8000);
+  try {
+    const resp = await fetch(url, {
+      signal: ac.signal,
+      headers: { 'User-Agent': 'two4-cosmos/1.0', Accept: 'image/*' },
+    });
+    if (!resp.ok) return null;
+    const arr = await resp.arrayBuffer();
+    return Buffer.from(arr);
+  } catch (err) {
+    console.error('Image download error:', err?.message || err);
+    return null;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function ensureIconBuffer(symbol, key, imageUrl) {
+  const client = getS3Client();
+  if (!client) return null;
+  const mapKey = `${symbol}::${key}`;
+  if (iconInFlight.has(mapKey)) return iconInFlight.get(mapKey);
+
+  const task = (async () => {
+    const targetUrl = imageUrl || (await resolveCoinImageUrl(symbol));
+    if (!targetUrl) return null;
+    const original = await downloadImageBuffer(targetUrl);
+    if (!original) return null;
+
+    let processed;
+    try {
+      processed = await sharp(original)
+        .resize(ICON_SIZE, ICON_SIZE, {
+          fit: 'contain',
+          background: { r: 0, g: 0, b: 0, alpha: 0 },
+          withoutEnlargement: true,
+        })
+        .webp({ quality: 85 })
+        .toBuffer();
+    } catch (err) {
+      console.error('Icon transform error:', err?.message || err);
+      return null;
+    }
+
+    try {
+      await client.send(new PutObjectCommand({
+        Bucket: AWS_BUCKET_NAME,
+        Key: key,
+        Body: processed,
+        ContentType: ICON_OUTPUT_TYPE,
+        CacheControl: ICON_S3_CACHE_CONTROL,
+      }));
+    } catch (err) {
+      console.error('S3 icon upload error:', err?.message || err);
+      // Still return processed buffer so the current request can respond.
+    }
+
+    return processed;
+  })()
+    .catch(err => {
+      console.error('Icon ensure error:', err?.message || err);
+      return null;
+    })
+    .finally(() => {
+      iconInFlight.delete(mapKey);
+    });
+
+  iconInFlight.set(mapKey, task);
+  return task;
+}
 
 app.use(express.static(path.join(__dirname, 'apps/web')));
 app.use('/media', express.static(path.join(__dirname, 'apps/web/media')));
@@ -798,47 +975,60 @@ app.get('/api/holidays', async (req, res) => {
   keep(key, payload);
 });
 
-// 아이콘: 로컬 있으면 그거, 없으면 코인게코 썸네일로 7일 캐시 리다이렉트
+// 아이콘: 로컬 우선 → S3(WebP) 캐시 → 원본/폴백 순
 app.get('/api/icon/:sym', async (req, res) => {
-  try {
-    const sym = (req.params.sym || '').toLowerCase();
-    const local = path.join(ICON_DIR, `${sym}.svg`);
+  const raw = (req.params.sym || '').trim();
+  const sym = raw.toLowerCase();
+  const local = path.join(ICON_DIR, `${sym}.svg`);
 
-    // 1) 로컬 svg 있으면 그걸로
+  try {
+    if (!sym) {
+      return res.redirect(302, FALLBACK_ICON);
+    }
+
     if (fs.existsSync(local)) {
       res.type('image/svg+xml');
       res.setHeader('Cache-Control', 'public, max-age=86400');
       return res.sendFile(local);
     }
 
-    // 2) 캐시된 리다이렉트 URL 있으면 바로 사용(7일)
-    const key = `ICON_URL:${sym.toUpperCase()}`;
-    const cached = hit2(key, 7 * 24 * 60 * 60 * 1000);
-    if (cached) {
-      res.setHeader('Cache-Control', 'public, max-age=86400');
-      return res.redirect(302, cached.body); // body=URL
+    const s3Ready = hasS3Support();
+    const key = s3Ready ? buildIconKey(sym) : null;
+
+    if (s3Ready && key) {
+      if (await trySendS3Icon(res, key)) return;
+
+      const resolvedUrl = await resolveCoinImageUrl(sym);
+      const buffer = resolvedUrl ? await ensureIconBuffer(sym, key, resolvedUrl) : null;
+
+      if (buffer && !res.headersSent) {
+        res.type(ICON_OUTPUT_TYPE);
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        res.setHeader('Content-Length', String(buffer.length));
+        res.send(buffer);
+        return;
+      }
+
+      if (!res.headersSent && await trySendS3Icon(res, key)) return;
+
+      if (resolvedUrl && !res.headersSent) {
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        return res.redirect(302, resolvedUrl);
+      }
+    } else {
+      const resolvedUrl = await resolveCoinImageUrl(sym);
+      if (resolvedUrl) {
+        res.setHeader('Cache-Control', 'public, max-age=86400');
+        return res.redirect(302, resolvedUrl);
+      }
     }
 
-    // 3) 코인게코 검색 → 같은 심볼 찾기 → thumb URL
-    const url = `https://api.coingecko.com/api/v3/search?query=${encodeURIComponent(sym)}`;
-    const payload = await proxyFetch(url, { 'User-Agent': 'two4-cosmos/1.0' });
-    let img = null;
-    if (payload.ok) {
-      const j = JSON.parse(payload.body || '{}');
-      const hit = (j.coins || []).find(c => (c.symbol || '').toLowerCase() === sym);
-      img = hit?.thumb || hit?.large || hit?.small || null;
+    if (!res.headersSent) {
+      return res.redirect(302, FALLBACK_ICON);
     }
-
-    if (img) {
-      keep(key, { ok: true, body: img, ct: 'text/plain' }); // URL 캐시
-      res.setHeader('Cache-Control', 'public, max-age=86400');
-      return res.redirect(302, img);
-    }
-
-    // 4) 마지막 폴백
-    return res.redirect(302, FALLBACK_ICON);
-  } catch {
-    return res.redirect(302, FALLBACK_ICON);
+  } catch (err) {
+    console.error('/api/icon error:', err?.message || err);
+    if (!res.headersSent) return res.redirect(302, FALLBACK_ICON);
   }
 });
 


### PR DESCRIPTION
## Summary
- add AWS S3 and sharp dependencies to support image processing and storage
- update environment configuration scaffolding to include the AWS storage prefix
- rewrite the /api/icon handler to resize coin logos, cache them in S3 as WebP, and fall back gracefully when needed

## Testing
- node --check server.js

------
https://chatgpt.com/codex/tasks/task_e_68cc02d2e8b0832fb6f5d6ef05ee86ff