### PR TITLE
Update Seed chatbot default model to x-ai/grok-4

### DIFF
--- a/apps/api/plugins/news-ko.js
+++ b/apps/api/plugins/news-ko.js
@@ -328,7 +328,7 @@ async function summarizeArticles(articles, fastify) {
   ];
 
   const body = {
-    model: process.env.OPENROUTER_MODEL || 'openrouter/auto',
+    model: process.env.OPENROUTER_MODEL || 'x-ai/grok-4',
     messages,
     temperature: 0.2,
     max_tokens: 700

--- a/apps/server/utils/chat.js
+++ b/apps/server/utils/chat.js
@@ -2,7 +2,7 @@ const express = require('express');
 const router = express.Router();
 
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
-const MODEL_ID = process.env.MODEL_ID || 'openrouter/auto';
+const MODEL_ID = process.env.MODEL_ID || 'x-ai/grok-4';
 const OPENROUTER_SITE_URL  = process.env.OPENROUTER_SITE_URL  || 'https://two4-production.up.railway.app';
 const OPENROUTER_SITE_NAME = process.env.OPENROUTER_SITE_NAME || 'TWO4 Seed AI';
 

--- a/apps/web/ai/server.cjs
+++ b/apps/web/ai/server.cjs
@@ -115,7 +115,7 @@ router.post('/chat', async (req, res) => {
     if (!req.cookies.sid) {
       res.cookie('sid', randomId(), { httpOnly: true, sameSite: 'lax' });
     }
-    const model = process.env.MODEL_ID || 'openrouter/auto';
+    const model = process.env.MODEL_ID || 'x-ai/grok-4';
     const { messages = [], temperature = 0.7, max_tokens = 500 } = req.body || {};
     const orRes = await fetch('https://openrouter.ai/api/v1/chat/completions', {
       method: 'POST',

--- a/apps/web/server.js
+++ b/apps/web/server.js
@@ -106,7 +106,7 @@ app.get('/api/price/fast', async (req, res) => {
 // 📌 OpenRouter 프록시 (Chat / Image)
 // ==============================
 const OPENROUTER_API_KEY = process.env.OPENROUTER_API_KEY;
-const MODEL_ID = process.env.MODEL_ID || 'openrouter/auto';
+const MODEL_ID = process.env.MODEL_ID || 'x-ai/grok-4';
 const OPENROUTER_SITE_URL  = process.env.OPENROUTER_SITE_URL  || 'https://two4-production.up.railway.app';
 const OPENROUTER_SITE_NAME = process.env.OPENROUTER_SITE_NAME || 'TWO4 Seed AI';
 

--- a/routes/news-ko.js
+++ b/routes/news-ko.js
@@ -329,7 +329,7 @@ async function summarizeArticles(articles, logger) {
   ];
 
   const body = {
-    model: process.env.OPENROUTER_MODEL || 'openrouter/auto',
+    model: process.env.OPENROUTER_MODEL || 'x-ai/grok-4',
     messages,
     temperature: 0.2,
     max_tokens: 700


### PR DESCRIPTION
## Summary
- set the Seed chat API default model to `x-ai/grok-4`
- align related OpenRouter integrations, including news summarization helpers, with the new model default

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd3cd76f3c832fa1d2e687ab8b7c47