### PR TITLE
feat: add method notice board experience

### DIFF
--- a/apps/web/include.js
+++ b/apps/web/include.js
@@ -3,7 +3,8 @@ window.addEventListener("DOMContentLoaded", async () => {
   const el = document.querySelector('[include-html]');
   if (!el) return;
   try {
-    const res = await fetch('header.html');
+    const includePath = el.getAttribute('include-html') || 'header.html';
+    const res = await fetch(includePath);
     const html = await res.text();
     el.innerHTML = html;
     el.querySelectorAll('script').forEach(old => {

--- a/apps/web/menu/method.html
+++ b/apps/web/menu/method.html
@@ -2,17 +2,27 @@
 <html lang="ko">
 <head>
   <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta http-equiv="refresh" content="0; url=method/">
   <title>METHOD | Two.4</title>
+  <script>
+    window.location.replace('method/');
+  </script>
   <style>
-    body{margin:0;background:linear-gradient(180deg,#03040a,#0a0713,#120024);color:cyan;
-         font-family:system-ui,Segoe UI,Roboto,sans-serif;text-align:center;padding-top:160px}
-    .page-title{opacity:.9}
+    body {
+      margin: 0;
+      min-height: 100vh;
+      display: grid;
+      place-items: center;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top, rgba(12, 8, 28, 0.95), #05040f);
+      color: #e7ffff;
+    }
+    a {
+      color: #8a2be2;
+    }
   </style>
 </head>
 <body>
-  <div include-html="header.html"></div>
-  <h2 class="page-title">[ METHOD (TECHNIQUE) ] 페이지는 현재 업데이트 진행 중입니다.</h2>
-  <script src="../include.js"></script>
+  <p>Redirecting to <a href="method/">METHOD (TECHNIQUE)</a>…</p>
 </body>
 </html>

--- a/apps/web/menu/method/index.html
+++ b/apps/web/menu/method/index.html
@@ -1,0 +1,648 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>METHOD | Two.4</title>
+  <style>
+    @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@500;600;700&family=Exo+2:wght@300;400;600&display=swap');
+
+    :root {
+      --page-bg: radial-gradient(circle at top, #120027 0%, #060010 45%, #020007 100%);
+      --surface-glass: rgba(10, 9, 25, 0.78);
+      --surface-panel: rgba(14, 16, 40, 0.68);
+      --text-primary: #e8f6ff;
+      --text-secondary: rgba(205, 235, 255, 0.75);
+      --text-tertiary: rgba(200, 224, 255, 0.55);
+      --accent: #64d7ff;
+      --accent-strong: #8a2be2;
+      --border-soft: rgba(100, 215, 255, 0.35);
+      --border-strong: rgba(138, 43, 226, 0.65);
+      --card-radius: 24px;
+      --shadow-strong: 0 18px 40px rgba(0, 0, 0, 0.45);
+    }
+
+    * {
+      box-sizing: border-box;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      font-family: 'Exo 2', 'Apple SD Gothic Neo', 'Noto Sans KR', sans-serif;
+      background: var(--page-bg);
+      color: var(--text-primary);
+      min-height: 100vh;
+      overflow-x: hidden;
+      position: relative;
+    }
+
+    body::before {
+      content: "";
+      position: fixed;
+      inset: 0;
+      background: radial-gradient(circle at 25% -10%, rgba(116, 69, 255, 0.18), transparent 55%),
+                  radial-gradient(circle at 80% 0%, rgba(72, 207, 255, 0.25), transparent 60%),
+                  radial-gradient(circle at 50% 100%, rgba(24, 9, 51, 0.55), rgba(1, 2, 12, 0.95));
+      z-index: -3;
+      filter: blur(0.3px);
+    }
+
+    .cosmic-grid {
+      position: fixed;
+      inset: 0;
+      background-image:
+        linear-gradient(rgba(118, 67, 255, 0.08) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(98, 247, 255, 0.05) 1px, transparent 1px);
+      background-size: 120px 120px;
+      opacity: 0.35;
+      z-index: -2;
+      animation: drift 40s linear infinite;
+      pointer-events: none;
+    }
+
+    .cosmic-particles {
+      position: fixed;
+      inset: 0;
+      overflow: hidden;
+      pointer-events: none;
+      z-index: -1;
+    }
+
+    .cosmic-particles span {
+      position: absolute;
+      width: 3px;
+      height: 3px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.85);
+      animation: twinkle 5s ease-in-out infinite;
+    }
+
+    .cosmic-particles span:nth-child(odd) {
+      animation-duration: 7s;
+      background: rgba(120, 220, 255, 0.85);
+    }
+
+    @keyframes drift {
+      0% { transform: translate3d(0, 0, 0); }
+      100% { transform: translate3d(120px, 160px, 0); }
+    }
+
+    @keyframes twinkle {
+      0%, 100% { opacity: 0.15; transform: scale(0.6); }
+      50% { opacity: 0.9; transform: scale(1.1); }
+    }
+
+    main {
+      position: relative;
+      max-width: 1200px;
+      margin: 0 auto;
+      padding: 160px 28px 96px;
+    }
+
+    .hero {
+      text-align: center;
+      margin-bottom: 54px;
+    }
+
+    .hero__eyebrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      letter-spacing: 0.32em;
+      font-size: 0.72rem;
+      font-family: 'Orbitron', sans-serif;
+      text-transform: uppercase;
+      color: rgba(151, 211, 255, 0.75);
+    }
+
+    .hero__eyebrow::before,
+    .hero__eyebrow::after {
+      content: "";
+      width: 36px;
+      height: 1px;
+      background: linear-gradient(to right, transparent, rgba(100, 215, 255, 0.6));
+      display: block;
+    }
+
+    .hero__title {
+      margin-top: 18px;
+      font-family: 'Orbitron', sans-serif;
+      font-size: clamp(2.35rem, 5vw, 3.4rem);
+      letter-spacing: 0.18em;
+      text-transform: uppercase;
+      text-shadow: 0 0 28px rgba(100, 215, 255, 0.55);
+    }
+
+    .hero__subtitle {
+      margin-top: 18px;
+      max-width: 720px;
+      margin-left: auto;
+      margin-right: auto;
+      font-size: 1.02rem;
+      color: var(--text-secondary);
+      line-height: 1.7;
+    }
+
+    .notice-board {
+      background: var(--surface-glass);
+      border-radius: var(--card-radius);
+      border: 1px solid rgba(100, 215, 255, 0.45);
+      box-shadow: var(--shadow-strong);
+      backdrop-filter: blur(26px);
+      -webkit-backdrop-filter: blur(26px);
+      overflow: hidden;
+    }
+
+    .notice-board__header {
+      padding: 32px clamp(20px, 6vw, 48px) 28px;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 24px;
+      align-items: flex-start;
+      justify-content: space-between;
+      border-bottom: 1px solid rgba(100, 215, 255, 0.2);
+    }
+
+    .board-title {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+
+    .board-title__badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 16px;
+      border-radius: 999px;
+      border: 1px solid rgba(100, 215, 255, 0.5);
+      background: rgba(14, 27, 45, 0.75);
+      font-family: 'Orbitron', sans-serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.28em;
+    }
+
+    .board-title__headline {
+      font-family: 'Orbitron', sans-serif;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+    }
+
+    .board-title__desc {
+      max-width: 540px;
+      font-size: 0.98rem;
+      color: var(--text-secondary);
+      line-height: 1.7;
+    }
+
+    .board-controls {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+      align-items: flex-end;
+      min-width: 220px;
+    }
+
+    .board-updated {
+      font-size: 0.82rem;
+      color: var(--text-tertiary);
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+    }
+
+    .board-filters {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: flex-end;
+    }
+
+    .board-filters button {
+      position: relative;
+      border: 1px solid rgba(100, 215, 255, 0.45);
+      border-radius: 999px;
+      padding: 9px 18px;
+      font-size: 0.82rem;
+      letter-spacing: 0.08em;
+      font-family: 'Orbitron', sans-serif;
+      text-transform: uppercase;
+      background: rgba(12, 24, 42, 0.7);
+      color: var(--text-secondary);
+      cursor: pointer;
+      transition: all 0.25s ease;
+    }
+
+    .board-filters button.active,
+    .board-filters button:hover {
+      color: var(--text-primary);
+      border-color: var(--accent);
+      box-shadow: 0 0 18px rgba(100, 215, 255, 0.4);
+    }
+
+    .notice-board__body {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
+      gap: clamp(28px, 5vw, 48px);
+      padding: 42px clamp(20px, 6vw, 48px) 46px;
+    }
+
+    .board-section {
+      display: flex;
+      flex-direction: column;
+      gap: 28px;
+    }
+
+    .board-section__title {
+      display: flex;
+      align-items: baseline;
+      gap: 16px;
+      font-family: 'Orbitron', sans-serif;
+      text-transform: uppercase;
+      letter-spacing: 0.2em;
+      color: rgba(133, 214, 255, 0.85);
+      font-size: 1.05rem;
+    }
+
+    .board-section__title::after {
+      content: "";
+      flex: 1;
+      height: 1px;
+      background: linear-gradient(to right, rgba(100, 215, 255, 0.6), transparent);
+    }
+
+    .card-grid {
+      display: grid;
+      gap: 22px;
+    }
+
+    .card-grid[data-columns="2"] {
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .method-card {
+      background: var(--surface-panel);
+      border-radius: 20px;
+      padding: 24px;
+      border: 1px solid rgba(100, 215, 255, 0.25);
+      position: relative;
+      overflow: hidden;
+      transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
+      min-height: 180px;
+    }
+
+    .method-card::before {
+      content: "";
+      position: absolute;
+      inset: -60% 20% auto -35%;
+      height: 120%;
+      background: radial-gradient(circle at center, rgba(100, 215, 255, 0.35), transparent 70%);
+      opacity: 0;
+      transition: opacity 0.4s ease;
+    }
+
+    .method-card:hover,
+    .method-card:focus-within {
+      transform: translateY(-6px);
+      border-color: rgba(138, 43, 226, 0.75);
+      box-shadow: 0 24px 38px rgba(27, 8, 56, 0.55);
+    }
+
+    .method-card:hover::before,
+    .method-card:focus-within::before {
+      opacity: 1;
+    }
+
+    .method-card__label {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      font-family: 'Orbitron', sans-serif;
+      font-size: 0.75rem;
+      letter-spacing: 0.18em;
+      color: rgba(100, 215, 255, 0.75);
+      text-transform: uppercase;
+    }
+
+    .method-card__title {
+      margin-top: 12px;
+      font-size: 1.18rem;
+      font-weight: 600;
+      letter-spacing: 0.05em;
+    }
+
+    .method-card__meta {
+      margin-top: 12px;
+      font-size: 0.86rem;
+      color: var(--text-secondary);
+      line-height: 1.6;
+    }
+
+    .method-card__list {
+      margin-top: 18px;
+      list-style: none;
+      display: grid;
+      gap: 6px;
+      font-size: 0.88rem;
+      color: var(--text-secondary);
+    }
+
+    .method-card__list li {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+    }
+
+    .method-card__list li::before {
+      content: "✦";
+      color: var(--accent);
+      font-size: 0.78rem;
+    }
+
+    .method-card__status {
+      margin-top: 20px;
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      font-size: 0.78rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: rgba(100, 215, 255, 0.65);
+    }
+
+    .pulse-dot {
+      width: 9px;
+      height: 9px;
+      border-radius: 50%;
+      background: var(--accent);
+      position: relative;
+      box-shadow: 0 0 12px rgba(100, 215, 255, 0.7);
+    }
+
+    .pulse-dot::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      border-radius: inherit;
+      background: rgba(100, 215, 255, 0.4);
+      animation: pulse 2.8s ease-out infinite;
+    }
+
+    @keyframes pulse {
+      0% { transform: scale(0.6); opacity: 0.8; }
+      70% { transform: scale(1.8); opacity: 0; }
+      100% { transform: scale(1.8); opacity: 0; }
+    }
+
+    .integration-panel {
+      background: linear-gradient(140deg, rgba(24, 16, 56, 0.92), rgba(19, 20, 45, 0.86));
+      border-radius: 20px;
+      border: 1px solid rgba(138, 43, 226, 0.42);
+      padding: 26px;
+      display: grid;
+      gap: 18px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .integration-panel::after {
+      content: "";
+      position: absolute;
+      inset: 20% -20% -40% 30%;
+      background: radial-gradient(circle at center, rgba(138, 43, 226, 0.4), transparent 70%);
+      opacity: 0.7;
+      pointer-events: none;
+    }
+
+    .integration-panel__title {
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+    }
+
+    .integration-panel__title span {
+      font-family: 'Orbitron', sans-serif;
+      letter-spacing: 0.32em;
+      font-size: 0.7rem;
+      color: rgba(177, 215, 255, 0.66);
+    }
+
+    .integration-panel__title h3 {
+      font-size: 1.28rem;
+      letter-spacing: 0.08em;
+    }
+
+    .integration-status {
+      display: grid;
+      gap: 16px;
+    }
+
+    .integration-status__item {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 14px 16px;
+      background: rgba(10, 15, 32, 0.7);
+      border-radius: 16px;
+      border: 1px solid rgba(100, 215, 255, 0.15);
+    }
+
+    .integration-status__item strong {
+      font-size: 0.92rem;
+      letter-spacing: 0.08em;
+    }
+
+    .status-pill {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      padding: 6px 14px;
+      border-radius: 999px;
+      font-size: 0.72rem;
+      letter-spacing: 0.14em;
+      text-transform: uppercase;
+      border: 1px solid rgba(100, 215, 255, 0.4);
+      color: rgba(204, 234, 255, 0.9);
+      background: rgba(17, 32, 52, 0.78);
+    }
+
+    .status-pill[data-status="connected"] {
+      border-color: rgba(0, 212, 155, 0.8);
+      color: rgba(213, 255, 247, 0.92);
+      background: rgba(9, 42, 32, 0.85);
+    }
+
+    .status-pill[data-status="syncing"] {
+      border-color: rgba(100, 215, 255, 0.8);
+      background: rgba(14, 29, 50, 0.85);
+      color: rgba(214, 240, 255, 0.92);
+    }
+
+    .status-pill[data-status="error"] {
+      border-color: rgba(255, 98, 126, 0.8);
+      background: rgba(54, 14, 26, 0.85);
+      color: rgba(255, 218, 228, 0.92);
+    }
+
+    .resource-list {
+      display: grid;
+      gap: 12px;
+      margin-top: 6px;
+    }
+
+    .resource-item {
+      display: flex;
+      align-items: center;
+      gap: 14px;
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+      padding: 10px 0;
+      border-bottom: 1px solid rgba(100, 215, 255, 0.08);
+    }
+
+    .resource-item:last-child {
+      border-bottom: none;
+    }
+
+    .resource-item svg {
+      width: 18px;
+      height: 18px;
+      color: rgba(100, 215, 255, 0.75);
+      flex-shrink: 0;
+    }
+
+    .resource-item a {
+      color: inherit;
+      text-decoration: none;
+      transition: color 0.25s ease;
+    }
+
+    .resource-item a:hover,
+    .resource-item a:focus {
+      color: var(--accent);
+    }
+
+    @media (max-width: 1080px) {
+      .notice-board__body {
+        grid-template-columns: 1fr;
+      }
+      .board-controls {
+        align-items: flex-start;
+        width: 100%;
+      }
+      .board-filters {
+        justify-content: flex-start;
+      }
+    }
+
+    @media (max-width: 720px) {
+      main {
+        padding: 140px 18px 72px;
+      }
+      .notice-board {
+        border-radius: 18px;
+      }
+      .board-title__desc {
+        font-size: 0.9rem;
+      }
+      .method-card {
+        padding: 20px;
+      }
+      .integration-panel {
+        padding: 22px;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="cosmic-grid" aria-hidden="true"></div>
+  <div class="cosmic-particles" aria-hidden="true">
+    <span style="top:8%;left:18%"></span>
+    <span style="top:26%;left:72%"></span>
+    <span style="top:52%;left:8%"></span>
+    <span style="top:68%;left:56%"></span>
+    <span style="top:34%;left:42%"></span>
+    <span style="top:78%;left:22%"></span>
+    <span style="top:14%;left:88%"></span>
+    <span style="top:62%;left:80%"></span>
+  </div>
+
+  <div include-html="../header.html"></div>
+
+  <main>
+    <section class="hero">
+      <span class="hero__eyebrow">Method / Technique Notice Board</span>
+      <h1 class="hero__title">METHOD</h1>
+      <p class="hero__subtitle">
+        트레이딩 전략을 구성하는 모든 신호와 조합을 한 곳에서 관리합니다. 실시간 데이터베이스와 AWS S3 리소스를
+        연동해 분석 재료, 템플릿, 백테스트 리포트를 지속적으로 업데이트합니다.
+      </p>
+    </section>
+
+    <section class="notice-board" aria-labelledby="method-board">
+      <div class="notice-board__header">
+        <div class="board-title">
+          <span class="board-title__badge">[ notice board ]</span>
+          <h2 id="method-board" class="board-title__headline">Indicators &amp; Combinations</h2>
+          <p class="board-title__desc">
+            인디케이터 스택, 필터 조합, 백테스트 결과를 열람하고 필요한 자료를 바로 호출할 수 있도록 구성했습니다.
+            카테고리를 선택하면 관련 정보와 리소스를 빠르게 탐색할 수 있습니다.
+          </p>
+        </div>
+        <div class="board-controls">
+          <p class="board-updated" id="boardUpdated">Last sync — 준비 중</p>
+          <div class="board-filters" role="tablist" aria-label="Indicator filters">
+            <button type="button" class="active" data-filter="all">All</button>
+            <button type="button" data-filter="volume">Volume</button>
+            <button type="button" data-filter="trend">Moving Avg</button>
+            <button type="button" data-filter="price">Candlesticks</button>
+            <button type="button" data-filter="derivatives">Open Interest</button>
+            <button type="button" data-filter="oscillator">Oscillators</button>
+            <button type="button" data-filter="momentum">Momentum</button>
+            <button type="button" data-filter="volatility">Volatility</button>
+            <button type="button" data-filter="custom">Others</button>
+          </div>
+        </div>
+      </div>
+
+      <div class="notice-board__body">
+        <section class="board-section" aria-labelledby="indicator-section">
+          <h3 id="indicator-section" class="board-section__title">Indicators <small>기본 신호</small></h3>
+          <div class="card-grid" data-columns="2" id="indicatorGrid" role="list"></div>
+        </section>
+
+        <section class="board-section" aria-labelledby="combination-section">
+          <h3 id="combination-section" class="board-section__title">Combinations <small>전략 조합</small></h3>
+          <div class="card-grid" id="combinationGrid" role="list"></div>
+          <div class="integration-panel">
+            <div class="integration-panel__title">
+              <span>integration status</span>
+              <h3>DB &amp; AWS S3 연동 현황</h3>
+              <p class="board-title__desc" style="margin-top:4px;max-width:540px;">
+                실시간 시그널 데이터는 전용 API 데이터베이스에서, 전략 리포트와 리소스는 S3 버킷에서 불러옵니다.
+                연결 상태는 자동으로 모니터링되며 장애 시 알림이 표시됩니다.
+              </p>
+            </div>
+            <div class="integration-status">
+              <div class="integration-status__item" data-integration="db">
+                <strong>Trading DB</strong>
+                <span class="status-pill" data-status="pending">Sync 준비 중</span>
+              </div>
+              <div class="integration-status__item" data-integration="s3">
+                <strong>AWS S3 Resources</strong>
+                <span class="status-pill" data-status="pending">Sync 준비 중</span>
+              </div>
+            </div>
+            <div class="resource-list" id="resourceList" aria-live="polite"></div>
+          </div>
+        </section>
+      </div>
+    </section>
+  </main>
+
+  <script src="../../include.js" defer></script>
+  <script src="./method.js" type="module"></script>
+</body>
+</html>

--- a/apps/web/menu/method/method.js
+++ b/apps/web/menu/method/method.js
@@ -1,0 +1,400 @@
+const API_BASE = '/api/method';
+
+const clone = value => (typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value)));
+
+const fallbackBoard = {
+  updatedAt: new Date().toISOString(),
+  indicators: [
+    {
+      slug: 'volume-depth',
+      label: '-Volume-',
+      title: '거래량 심도 & 누적 흐름',
+      description: '현물 · 선물 거래량을 통합해 강도, 누적 델타를 추적합니다.',
+      highlights: [
+        '거래소별 실시간 체결 집계',
+        '세션 구간별 누적 델타/OBV',
+        '고래·기관 지갑 흐름 연동'
+      ],
+      status: { state: 'pending', label: 'DB 연동 대기', source: 'db' },
+      filter: 'volume'
+    },
+    {
+      slug: 'moving-average-suite',
+      label: '-Moving Averages-',
+      title: '트렌드 밴드 & 적응형 평균',
+      description: '멀티 타임프레임 EMA/SMA와 적응형 MA로 추세 밴드를 구성합니다.',
+      highlights: [
+        'HTF/LTF 멀티 레이어 추세 지도',
+        'KAMA · HMA · WMA 혼합 필터',
+        '크로스오버 이벤트 자동 라벨링'
+      ],
+      status: { state: 'pending', label: '시그널 정렬 중', source: 'db' },
+      filter: 'trend'
+    },
+    {
+      slug: 'candlestick-lab',
+      label: '-Candlesticks-',
+      title: '캔들 패턴 라이브러리',
+      description: '패턴과 거래량, 시장 미세구조 데이터를 결합해 컨텍스트를 제공합니다.',
+      highlights: [
+        'AI 패턴 스코어 · 확률 매핑',
+        '볼륨 컨펌 / 라인 브레이크 감시',
+        '세션 이벤트 주석 자동화'
+      ],
+      status: { state: 'pending', label: '패턴 피드 연결 대기', source: 'db' },
+      filter: 'price'
+    },
+    {
+      slug: 'open-interest-monitor',
+      label: '-Open Interest-',
+      title: 'OI 변동 & 파생상품 감시',
+      description: '선물 미결제약정, 펀딩, 베이시스 데이터를 통합해 레버리지 포지션을 추적합니다.',
+      highlights: [
+        '거래소별 롱/숏 비율 디컴포즈',
+        '펀딩레이트 과열 구간 알림',
+        '커브 구조(Contango/Backwardation) 시각화'
+      ],
+      status: { state: 'pending', label: 'Derivatives API 연결 중', source: 'db' },
+      filter: 'derivatives'
+    },
+    {
+      slug: 'oscillator-suite',
+      label: '-Oscillators-',
+      title: '사이클 스캐너',
+      description: 'RSI, Stochastic, MACD 등 변동성 조정 오실레이터를 묶어 과매수/과매도 구간을 탐지합니다.',
+      highlights: [
+        'EMA 평활화된 RSI 히트맵',
+        '디버전스 자동 태깅',
+        '미세 사이클 위상 정렬'
+      ],
+      status: { state: 'pending', label: '오실레이터 세트 로딩', source: 'db' },
+      filter: 'oscillator'
+    },
+    {
+      slug: 'momentum-engine',
+      label: '-Momentum-',
+      title: '모멘텀 & 추세 힘 지수',
+      description: 'ROC, CCI, DMI를 혼합한 맞춤형 모멘텀 스코어를 제공합니다.',
+      highlights: [
+        '레이더 차트 기반 스코어 보드',
+        '타임 디케이 기반 랭킹',
+        '이벤트 트리거 알림'
+      ],
+      status: { state: 'pending', label: '랭킹 메트릭 계산 중', source: 'db' },
+      filter: 'momentum'
+    },
+    {
+      slug: 'volatility-lab',
+      label: '-Volatility-',
+      title: '변동성 공명 실험실',
+      description: 'ATR, HV, 옵션 IV를 통합한 변동성 클러스터 분석.',
+      highlights: [
+        '스파이크/드롭 감지',
+        '옵션 히스토리컬 vs. 임플라이드 비교',
+        '공포/탐욕 밴드 추적'
+      ],
+      status: { state: 'pending', label: 'Volatility feed 준비 중', source: 'db' },
+      filter: 'volatility'
+    },
+    {
+      slug: 'custom-lab',
+      label: '-Others-',
+      title: '커스텀 실험 모듈',
+      description: '온체인, 소셜, 거시 데이터를 결합한 맞춤형 실험 공간입니다.',
+      highlights: [
+        '온체인 플로우 / 토큰 로테이션',
+        '뉴스 감성 지표 및 AI 스코어',
+        '거시 이벤트 대비 시나리오'
+      ],
+      status: { state: 'pending', label: '외부 데이터 브리지 동기화', source: 'db' },
+      filter: 'custom'
+    }
+  ],
+  combinations: [
+    {
+      slug: 'multi-indicator-setup',
+      label: 'Multi-Indicator Setup',
+      title: '멀티 레이어 시그널 세트',
+      description: '인디케이터 묶음을 프리셋으로 저장하고, 상황별 최적화된 시나리오를 제공합니다.',
+      highlights: [
+        '볼륨 + 추세 + 오실레이터 동시 확인',
+        '조건부 알림 / 시나리오 플래너',
+        '리밸런싱 히스토리 추적'
+      ],
+      status: { state: 'pending', label: 'Preset 업데이트 예정', source: 'db' },
+      filters: ['volume', 'trend', 'oscillator']
+    },
+    {
+      slug: 'signal-filters',
+      label: 'Signal Filters',
+      title: '시그널 필터 체계',
+      description: '거짓 시그널 제거를 위한 필터 체인을 구성하고 성능을 검증합니다.',
+      highlights: [
+        '시장 구조 Breaker 감지',
+        '히스테리시스 기반 필터',
+        'P&L 충격 분석 리포트'
+      ],
+      status: { state: 'pending', label: '필터 체인 설계 중', source: 'db' },
+      filters: ['price', 'momentum', 'oscillator']
+    },
+    {
+      slug: 'backtest-results',
+      label: 'Backtest Results',
+      title: '백테스트 리포트',
+      description: 'AWS S3에서 전략별 리포트를 불러와 성과를 검증하고 배포합니다.',
+      highlights: [
+        '전략별 KPI & 드로다운 테이블',
+        '워킹/포워드 테스트 전환 로그',
+        'S3 리포트 자동 보존 정책'
+      ],
+      status: { state: 'pending', label: 'S3 리소스 연결 대기', source: 's3' },
+      filters: ['volatility', 'trend', 'custom']
+    }
+  ],
+  integrations: {
+    db: { state: 'pending', label: 'Sync 준비 중' },
+    s3: { state: 'pending', label: 'Sync 준비 중' }
+  },
+  resources: [
+    {
+      title: 'Two.4 Strategy Blueprint (샘플)',
+      href: '#',
+      meta: 'PDF · 1.2MB · AWS S3',
+      source: 's3'
+    },
+    {
+      title: 'Indicator Stack Template (샘플)',
+      href: '#',
+      meta: 'JSON · 38KB · DB Export',
+      source: 'db'
+    }
+  ]
+};
+
+const integrationLabels = {
+  connected: 'Connected',
+  syncing: 'Syncing',
+  pending: 'Sync 준비 중',
+  error: 'Error'
+};
+
+function formatUpdatedAt(timestamp) {
+  if (!timestamp) return 'Last sync — 준비 중';
+  try {
+    const date = new Date(timestamp);
+    if (Number.isNaN(date.getTime())) return 'Last sync — 준비 중';
+    const formatted = new Intl.DateTimeFormat('ko-KR', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit'
+    }).format(date);
+    return `Last sync — ${formatted}`;
+  } catch (error) {
+    return 'Last sync — 준비 중';
+  }
+}
+
+function createList(items = []) {
+  const list = document.createElement('ul');
+  list.className = 'method-card__list';
+  items.forEach(text => {
+    const li = document.createElement('li');
+    li.textContent = text;
+    list.appendChild(li);
+  });
+  return list;
+}
+
+function createCard(item) {
+  const article = document.createElement('article');
+  article.className = 'method-card';
+  article.dataset.group = item.filter || 'all';
+  article.setAttribute('role', 'listitem');
+
+  const label = document.createElement('span');
+  label.className = 'method-card__label';
+  label.textContent = item.label;
+
+  const title = document.createElement('h4');
+  title.className = 'method-card__title';
+  title.textContent = item.title;
+
+  const meta = document.createElement('p');
+  meta.className = 'method-card__meta';
+  meta.textContent = item.description;
+
+  article.appendChild(label);
+  article.appendChild(title);
+  article.appendChild(meta);
+  article.appendChild(createList(item.highlights));
+
+  if (item.status) {
+    const status = document.createElement('div');
+    status.className = 'method-card__status';
+    status.innerHTML = `<span class="pulse-dot" aria-hidden="true"></span>${item.status.label}`;
+    status.dataset.source = item.status.source || 'db';
+    article.appendChild(status);
+  }
+
+  return article;
+}
+
+function createComboCard(item) {
+  const card = createCard(item);
+  if (item.filters) {
+    card.dataset.groups = item.filters.join(',');
+  }
+  return card;
+}
+
+function applyBoardData(board) {
+  const indicatorGrid = document.getElementById('indicatorGrid');
+  const combinationGrid = document.getElementById('combinationGrid');
+  const boardUpdated = document.getElementById('boardUpdated');
+
+  indicatorGrid.innerHTML = '';
+  combinationGrid.innerHTML = '';
+
+  board.indicators.forEach(entry => {
+    indicatorGrid.appendChild(createCard(entry));
+  });
+
+  board.combinations.forEach(entry => {
+    combinationGrid.appendChild(createComboCard(entry));
+  });
+
+  boardUpdated.textContent = formatUpdatedAt(board.updatedAt);
+}
+
+function updateIntegrationStatus(key, payload) {
+  const row = document.querySelector(`.integration-status__item[data-integration="${key}"]`);
+  if (!row) return;
+  const pill = row.querySelector('.status-pill');
+  if (!pill) return;
+  const state = payload?.state || 'pending';
+  const label = payload?.label || integrationLabels[state] || integrationLabels.pending;
+  pill.dataset.status = state;
+  pill.textContent = label;
+}
+
+function renderResources(resources = []) {
+  const list = document.getElementById('resourceList');
+  if (!list) return;
+  list.innerHTML = '';
+
+  if (!resources.length) {
+    const empty = document.createElement('p');
+    empty.className = 'board-title__desc';
+    empty.textContent = '연결이 완료되면 전략 리포트와 템플릿이 자동으로 표시됩니다.';
+    list.appendChild(empty);
+    return;
+  }
+
+  resources.forEach(item => {
+    const row = document.createElement('div');
+    row.className = 'resource-item';
+    row.innerHTML = `
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
+        <path d="M5 8.5a1.5 1.5 0 0 1 1.5-1.5h11A1.5 1.5 0 0 1 19 8.5v7a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 5 15.5v-7Z" />
+        <path d="M9 6.5V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1.5" />
+      </svg>
+      <div>
+        <a href="${item.href}" target="_blank" rel="noopener" aria-label="${item.title}">${item.title}</a>
+        <div style="font-size:0.76rem;color:rgba(200,224,255,0.55);margin-top:4px;">${item.meta || ''}</div>
+      </div>
+    `;
+    list.appendChild(row);
+  });
+}
+
+function setupFilters() {
+  const buttons = document.querySelectorAll('.board-filters button');
+  const indicatorCards = () => Array.from(document.querySelectorAll('#indicatorGrid .method-card'));
+  const comboCards = () => Array.from(document.querySelectorAll('#combinationGrid .method-card'));
+
+  function handleFilter(filter) {
+    buttons.forEach(btn => btn.classList.toggle('active', btn.dataset.filter === filter));
+
+    indicatorCards().forEach(card => {
+      const isVisible = filter === 'all' || card.dataset.group === filter;
+      card.style.display = isVisible ? '' : 'none';
+    });
+
+    comboCards().forEach(card => {
+      const groups = (card.dataset.groups || '').split(',').filter(Boolean);
+      const isVisible = filter === 'all' || groups.includes(filter);
+      card.style.display = isVisible ? '' : 'none';
+    });
+  }
+
+  buttons.forEach(button => {
+    button.addEventListener('click', () => handleFilter(button.dataset.filter));
+  });
+
+  const initial = document.querySelector('.board-filters button.active');
+  handleFilter(initial ? initial.dataset.filter : 'all');
+}
+
+async function fetchJSON(url) {
+  const response = await fetch(url);
+  if (!response.ok) throw new Error(`Request failed: ${response.status}`);
+  return response.json();
+}
+
+async function loadBoard() {
+  let boardData = clone(fallbackBoard);
+
+  try {
+    const remote = await fetchJSON(`${API_BASE}/board`);
+    boardData = {
+      ...boardData,
+      ...remote,
+      indicators: remote?.indicators?.length ? remote.indicators : boardData.indicators,
+      combinations: remote?.combinations?.length ? remote.combinations : boardData.combinations,
+      resources: remote?.resources ?? boardData.resources,
+      integrations: { ...boardData.integrations, ...remote?.integrations }
+    };
+  } catch (error) {
+    console.info('[METHOD] Using fallback board data.', error);
+  }
+
+  applyBoardData(boardData);
+  setupFilters();
+  updateIntegrationStatus('db', boardData.integrations?.db);
+  updateIntegrationStatus('s3', boardData.integrations?.s3);
+  renderResources(boardData.resources);
+
+  await Promise.allSettled([
+    refreshIntegration('db'),
+    refreshIntegration('s3'),
+    refreshResources()
+  ]);
+}
+
+async function refreshIntegration(key) {
+  try {
+    const payload = await fetchJSON(`${API_BASE}/status/${key}`);
+    updateIntegrationStatus(key, payload);
+  } catch (error) {
+    console.info(`[METHOD] ${key} status fallback.`, error);
+  }
+}
+
+async function refreshResources() {
+  try {
+    const payload = await fetchJSON(`${API_BASE}/resources`);
+    if (Array.isArray(payload) && payload.length) {
+      renderResources(payload);
+    }
+  } catch (error) {
+    console.info('[METHOD] Resource list fallback.', error);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  loadBoard().catch(error => {
+    console.error('[METHOD] 초기화 실패', error);
+  });
+});


### PR DESCRIPTION
## Summary
- build a dedicated METHOD notice board page with indicators, strategy combinations, and integration status panels
- implement dynamic board rendering with API fallbacks for database and AWS S3 resources
- support nested header includes and redirect the legacy METHOD entry point to the new experience

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d39da3b074832f929b073fbac94f66