### PR TITLE
Revamp METHOD forum layout

### DIFF
--- a/apps/web/menu/method/index.html
+++ b/apps/web/menu/method/index.html
@@ -11,13 +11,14 @@
       --page-bg: radial-gradient(circle at top, #120027 0%, #060010 45%, #020007 100%);
       --surface-glass: rgba(10, 9, 25, 0.78);
       --surface-panel: rgba(14, 16, 40, 0.68);
+      --surface-panel-strong: rgba(18, 22, 48, 0.82);
       --text-primary: #e8f6ff;
-      --text-secondary: rgba(205, 235, 255, 0.75);
-      --text-tertiary: rgba(200, 224, 255, 0.55);
+      --text-secondary: rgba(205, 235, 255, 0.78);
+      --text-tertiary: rgba(200, 224, 255, 0.58);
       --accent: #64d7ff;
       --accent-strong: #8a2be2;
       --border-soft: rgba(100, 215, 255, 0.35);
-      --border-strong: rgba(138, 43, 226, 0.65);
+      --border-strong: rgba(138, 43, 226, 0.58);
       --card-radius: 24px;
       --shadow-strong: 0 18px 40px rgba(0, 0, 0, 0.45);
     }
@@ -42,8 +43,8 @@
       position: fixed;
       inset: 0;
       background: radial-gradient(circle at 25% -10%, rgba(116, 69, 255, 0.18), transparent 55%),
-                  radial-gradient(circle at 80% 0%, rgba(72, 207, 255, 0.25), transparent 60%),
-                  radial-gradient(circle at 50% 100%, rgba(24, 9, 51, 0.55), rgba(1, 2, 12, 0.95));
+        radial-gradient(circle at 80% 0%, rgba(72, 207, 255, 0.25), transparent 60%),
+        radial-gradient(circle at 50% 100%, rgba(24, 9, 51, 0.55), rgba(1, 2, 12, 0.95));
       z-index: -3;
       filter: blur(0.3px);
     }
@@ -95,7 +96,7 @@
 
     main {
       position: relative;
-      max-width: 1200px;
+      max-width: 1240px;
       margin: 0 auto;
       padding: 160px 28px 96px;
     }
@@ -144,396 +145,681 @@
       line-height: 1.7;
     }
 
-    .notice-board {
+    .method-forum {
       background: var(--surface-glass);
       border-radius: var(--card-radius);
-      border: 1px solid rgba(100, 215, 255, 0.45);
+      border: 1px solid rgba(100, 215, 255, 0.28);
       box-shadow: var(--shadow-strong);
-      backdrop-filter: blur(26px);
-      -webkit-backdrop-filter: blur(26px);
+      backdrop-filter: blur(28px);
+      -webkit-backdrop-filter: blur(28px);
       overflow: hidden;
     }
 
-    .notice-board__header {
-      padding: 32px clamp(20px, 6vw, 48px) 28px;
+    .method-forum__layout {
       display: flex;
-      flex-wrap: wrap;
-      gap: 24px;
-      align-items: flex-start;
-      justify-content: space-between;
-      border-bottom: 1px solid rgba(100, 215, 255, 0.2);
+      min-height: 640px;
     }
 
-    .board-title {
-      display: flex;
-      flex-direction: column;
-      gap: 12px;
-    }
-
-    .board-title__badge {
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      padding: 6px 16px;
-      border-radius: 999px;
-      border: 1px solid rgba(100, 215, 255, 0.5);
-      background: rgba(14, 27, 45, 0.75);
-      font-family: 'Orbitron', sans-serif;
-      font-size: 0.72rem;
-      letter-spacing: 0.28em;
-    }
-
-    .board-title__headline {
-      font-family: 'Orbitron', sans-serif;
-      font-size: clamp(1.8rem, 3vw, 2.4rem);
-      letter-spacing: 0.14em;
-      text-transform: uppercase;
-    }
-
-    .board-title__desc {
-      max-width: 540px;
-      font-size: 0.98rem;
-      color: var(--text-secondary);
-      line-height: 1.7;
-    }
-
-    .board-controls {
-      display: flex;
-      flex-direction: column;
-      gap: 16px;
-      align-items: flex-end;
-      min-width: 220px;
-    }
-
-    .board-updated {
-      font-size: 0.82rem;
-      color: var(--text-tertiary);
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-    }
-
-    .board-filters {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      justify-content: flex-end;
-    }
-
-    .board-filters button {
+    .forum-sidebar {
+      width: 280px;
+      padding: 40px 28px 44px;
+      background: linear-gradient(180deg, rgba(12, 16, 36, 0.92), rgba(6, 8, 18, 0.88));
+      border-right: 1px solid rgba(100, 215, 255, 0.12);
       position: relative;
-      border: 1px solid rgba(100, 215, 255, 0.45);
-      border-radius: 999px;
-      padding: 9px 18px;
-      font-size: 0.82rem;
-      letter-spacing: 0.08em;
+      overflow-y: auto;
+    }
+
+    .forum-sidebar::after {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: radial-gradient(circle at 18% 12%, rgba(98, 247, 255, 0.12), transparent 50%);
+      pointer-events: none;
+    }
+
+    .forum-sidebar__header {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      margin-bottom: 32px;
+    }
+
+    .forum-sidebar__eyebrow {
       font-family: 'Orbitron', sans-serif;
+      letter-spacing: 0.28em;
+      font-size: 0.7rem;
+      color: rgba(151, 211, 255, 0.66);
       text-transform: uppercase;
-      background: rgba(12, 24, 42, 0.7);
-      color: var(--text-secondary);
-      cursor: pointer;
-      transition: all 0.25s ease;
     }
 
-    .board-filters button.active,
-    .board-filters button:hover {
-      color: var(--text-primary);
-      border-color: var(--accent);
-      box-shadow: 0 0 18px rgba(100, 215, 255, 0.4);
+    .forum-sidebar__title {
+      font-family: 'Orbitron', sans-serif;
+      font-size: 1.4rem;
+      letter-spacing: 0.16em;
     }
 
-    .notice-board__body {
+    .category-group {
+      margin-bottom: 28px;
+    }
+
+    .category-group__title {
+      font-family: 'Orbitron', sans-serif;
+      font-size: 0.78rem;
+      letter-spacing: 0.2em;
+      text-transform: uppercase;
+      color: rgba(151, 211, 255, 0.72);
+      margin-bottom: 16px;
+    }
+
+    .category-nav {
+      list-style: none;
       display: grid;
-      grid-template-columns: minmax(0, 1fr) minmax(0, 0.92fr);
-      gap: clamp(28px, 5vw, 48px);
-      padding: 42px clamp(20px, 6vw, 48px) 46px;
+      gap: 10px;
     }
 
-    .board-section {
+    .category-nav button {
+      width: 100%;
+      text-align: left;
+      border: 1px solid rgba(100, 215, 255, 0.18);
+      border-radius: 16px;
+      padding: 14px 16px;
+      background: rgba(10, 12, 28, 0.55);
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      font-weight: 500;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      transition: border-color 0.28s ease, color 0.28s ease, transform 0.28s ease, background 0.28s ease;
+    }
+
+    .category-nav button::after {
+      content: attr(data-label);
+      display: block;
+      font-size: 0.72rem;
+      color: rgba(151, 211, 255, 0.55);
+      letter-spacing: 0.08em;
+      margin-top: 6px;
+    }
+
+    .category-nav button:hover,
+    .category-nav button:focus {
+      outline: none;
+      border-color: rgba(100, 215, 255, 0.45);
+      color: var(--text-primary);
+      transform: translateX(4px);
+      background: rgba(15, 20, 40, 0.85);
+    }
+
+    .category-nav button.active {
+      border-color: var(--accent-strong);
+      color: var(--text-primary);
+      background: linear-gradient(140deg, rgba(40, 20, 70, 0.85), rgba(18, 30, 54, 0.85));
+      box-shadow: 0 12px 28px rgba(30, 10, 58, 0.55);
+    }
+
+    .method-forum__main {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      position: relative;
+    }
+
+    .forum-view {
+      padding: 40px clamp(28px, 6vw, 48px) 52px;
       display: flex;
       flex-direction: column;
       gap: 28px;
     }
 
-    .board-section__title {
+    .forum-view[hidden] {
+      display: none;
+    }
+
+    .forum-header {
       display: flex;
-      align-items: baseline;
-      gap: 16px;
+      flex-wrap: wrap;
+      gap: 24px;
+      align-items: flex-start;
+      justify-content: space-between;
+      border-bottom: 1px solid rgba(100, 215, 255, 0.16);
+      padding-bottom: 24px;
+    }
+
+    .forum-header__info {
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+      max-width: 520px;
+    }
+
+    .forum-header__badge {
       font-family: 'Orbitron', sans-serif;
+      letter-spacing: 0.26em;
+      font-size: 0.72rem;
       text-transform: uppercase;
-      letter-spacing: 0.2em;
-      color: rgba(133, 214, 255, 0.85);
-      font-size: 1.05rem;
+      color: rgba(151, 211, 255, 0.7);
     }
 
-    .board-section__title::after {
-      content: "";
-      flex: 1;
-      height: 1px;
-      background: linear-gradient(to right, rgba(100, 215, 255, 0.6), transparent);
+    .forum-header__title {
+      font-family: 'Orbitron', sans-serif;
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      letter-spacing: 0.12em;
     }
 
-    .card-grid {
+    .forum-header__meta {
+      color: var(--text-secondary);
+      line-height: 1.7;
+      font-size: 0.98rem;
+    }
+
+    .forum-header__actions {
+      display: flex;
+      flex-direction: column;
+      gap: 14px;
+      align-items: flex-end;
+      min-width: 220px;
+    }
+
+    .forum-sync {
+      font-size: 0.82rem;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      color: var(--text-tertiary);
+    }
+
+    .new-post-btn {
+      background: linear-gradient(120deg, rgba(255, 0, 212, 0.9), rgba(100, 215, 255, 0.95));
+      border: none;
+      color: #0a0a1e;
+      font-weight: 700;
+      font-size: 0.92rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      border-radius: 999px;
+      padding: 14px 26px;
+      cursor: pointer;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
+      font-family: 'Orbitron', sans-serif;
+    }
+
+    .new-post-btn:hover {
+      transform: translateY(-2px) scale(1.02);
+      box-shadow: 0 18px 32px rgba(120, 45, 160, 0.45);
+    }
+
+    .category-hero {
       display: grid;
-      gap: 22px;
-    }
-
-    .card-grid[data-columns="2"] {
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    }
-
-    .method-card {
-      background: var(--surface-panel);
+      grid-template-columns: 120px 1fr;
+      gap: 24px;
+      align-items: center;
+      background: linear-gradient(130deg, rgba(28, 20, 64, 0.82), rgba(14, 20, 42, 0.78));
       border-radius: 20px;
-      padding: 24px;
-      border: 1px solid rgba(100, 215, 255, 0.25);
+      border: 1px solid rgba(100, 215, 255, 0.22);
+      padding: 26px;
       position: relative;
       overflow: hidden;
-      transition: transform 0.35s ease, border-color 0.35s ease, box-shadow 0.35s ease;
-      min-height: 180px;
     }
 
-    .method-card::before {
+    .category-hero::after {
       content: "";
       position: absolute;
-      inset: -60% 20% auto -35%;
-      height: 120%;
-      background: radial-gradient(circle at center, rgba(100, 215, 255, 0.35), transparent 70%);
-      opacity: 0;
-      transition: opacity 0.4s ease;
+      inset: 12% -30% -60% 32%;
+      background: radial-gradient(circle at center, rgba(138, 43, 226, 0.45), transparent 70%);
+      opacity: 0.6;
+      pointer-events: none;
     }
 
-    .method-card:hover,
-    .method-card:focus-within {
-      transform: translateY(-6px);
-      border-color: rgba(138, 43, 226, 0.75);
-      box-shadow: 0 24px 38px rgba(27, 8, 56, 0.55);
-    }
-
-    .method-card:hover::before,
-    .method-card:focus-within::before {
-      opacity: 1;
-    }
-
-    .method-card__label {
-      display: inline-flex;
-      align-items: center;
-      gap: 8px;
-      font-family: 'Orbitron', sans-serif;
-      font-size: 0.75rem;
-      letter-spacing: 0.18em;
-      color: rgba(100, 215, 255, 0.75);
-      text-transform: uppercase;
-    }
-
-    .method-card__title {
-      margin-top: 12px;
-      font-size: 1.18rem;
-      font-weight: 600;
-      letter-spacing: 0.05em;
-    }
-
-    .method-card__meta {
-      margin-top: 12px;
-      font-size: 0.86rem;
-      color: var(--text-secondary);
-      line-height: 1.6;
-    }
-
-    .method-card__list {
-      margin-top: 18px;
-      list-style: none;
+    .category-hero__visual {
+      width: 100px;
+      height: 100px;
+      border-radius: 24px;
+      background: rgba(12, 20, 48, 0.75);
+      border: 1px solid rgba(100, 215, 255, 0.25);
       display: grid;
-      gap: 6px;
-      font-size: 0.88rem;
-      color: var(--text-secondary);
+      place-items: center;
+      font-size: 2.6rem;
+      position: relative;
+      box-shadow: 0 18px 36px rgba(18, 14, 42, 0.65);
     }
 
-    .method-card__list li {
+    .category-hero__visual::before {
+      content: "";
+      position: absolute;
+      inset: -18px;
+      border-radius: 32px;
+      border: 1px solid rgba(100, 215, 255, 0.18);
+      opacity: 0.6;
+    }
+
+    .category-hero__text {
+      position: relative;
+      z-index: 1;
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .category-hero__text h3 {
+      font-size: 1.32rem;
+      letter-spacing: 0.08em;
+    }
+
+    .category-hero__text p {
+      color: var(--text-secondary);
+      line-height: 1.7;
+      font-size: 0.96rem;
+      max-width: 560px;
+    }
+
+    .category-description {
+      background: rgba(10, 15, 34, 0.78);
+      border-radius: 18px;
+      border: 1px solid rgba(100, 215, 255, 0.18);
+      padding: 26px;
+      display: grid;
+      gap: 18px;
+    }
+
+    .description-header {
       display: flex;
       align-items: center;
+      justify-content: space-between;
+      gap: 18px;
+    }
+
+    .description-header h3 {
+      font-size: 1.08rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      font-family: 'Orbitron', sans-serif;
+    }
+
+    .edit-description-btn {
+      background: rgba(100, 215, 255, 0.12);
+      border: 1px solid rgba(100, 215, 255, 0.32);
+      color: var(--text-primary);
+      padding: 8px 16px;
+      border-radius: 12px;
+      font-size: 0.82rem;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .edit-description-btn:hover {
+      background: rgba(100, 215, 255, 0.22);
+      border-color: rgba(100, 215, 255, 0.5);
+    }
+
+    .description-content {
+      color: var(--text-secondary);
+      line-height: 1.72;
+      font-size: 0.98rem;
+    }
+
+    .description-edit[hidden] {
+      display: none;
+    }
+
+    .description-edit textarea {
+      width: 100%;
+      min-height: 140px;
+      background: rgba(5, 8, 20, 0.78);
+      border: 1px solid rgba(100, 215, 255, 0.22);
+      border-radius: 12px;
+      color: var(--text-primary);
+      padding: 14px;
+      font-size: 0.95rem;
+      font-family: inherit;
+      resize: vertical;
+    }
+
+    .description-edit textarea:focus {
+      outline: none;
+      border-color: rgba(100, 215, 255, 0.5);
+      box-shadow: 0 0 0 3px rgba(100, 215, 255, 0.18);
+    }
+
+    .edit-actions {
+      display: flex;
+      justify-content: flex-end;
+      gap: 12px;
+      margin-top: 12px;
+    }
+
+    .btn {
+      padding: 10px 20px;
+      border-radius: 12px;
+      border: none;
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      cursor: pointer;
+      transition: transform 0.2s ease, opacity 0.2s ease;
+    }
+
+    .btn:hover {
+      transform: translateY(-1px);
+      opacity: 0.9;
+    }
+
+    .btn-primary {
+      background: rgba(100, 215, 255, 0.85);
+      color: #04121f;
+    }
+
+    .btn-secondary {
+      background: rgba(26, 34, 56, 0.9);
+      color: var(--text-primary);
+      border: 1px solid rgba(100, 215, 255, 0.2);
+    }
+
+    .post-form {
+      background: rgba(10, 14, 30, 0.78);
+      border-radius: 18px;
+      border: 1px solid rgba(100, 215, 255, 0.18);
+      padding: 26px;
+      display: grid;
+      gap: 18px;
+    }
+
+    .post-form[hidden] {
+      display: none;
+    }
+
+    .form-group {
+      display: grid;
+      gap: 8px;
+    }
+
+    .form-group label {
+      font-weight: 600;
+      letter-spacing: 0.06em;
+      font-size: 0.9rem;
+      color: rgba(205, 235, 255, 0.82);
+    }
+
+    .form-group input,
+    .form-group textarea,
+    .form-group select {
+      width: 100%;
+      padding: 12px 14px;
+      background: rgba(5, 8, 18, 0.82);
+      border: 1px solid rgba(100, 215, 255, 0.18);
+      border-radius: 12px;
+      color: var(--text-primary);
+      font-size: 0.94rem;
+      font-family: inherit;
+    }
+
+    .form-group input:focus,
+    .form-group textarea:focus,
+    .form-group select:focus {
+      outline: none;
+      border-color: rgba(100, 215, 255, 0.45);
+      box-shadow: 0 0 0 3px rgba(100, 215, 255, 0.18);
+    }
+
+    .form-group textarea {
+      min-height: 220px;
+      resize: vertical;
+    }
+
+    .form-actions {
+      display: flex;
+      justify-content: flex-end;
       gap: 12px;
     }
 
-    .method-card__list li::before {
-      content: "✦";
-      color: var(--accent);
-      font-size: 0.78rem;
+    .post-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 24px;
+      margin-top: 6px;
     }
 
-    .method-card__status {
-      margin-top: 20px;
-      display: inline-flex;
-      align-items: center;
-      gap: 10px;
-      font-size: 0.78rem;
-      letter-spacing: 0.12em;
-      text-transform: uppercase;
-      color: rgba(100, 215, 255, 0.65);
-    }
-
-    .pulse-dot {
-      width: 9px;
-      height: 9px;
-      border-radius: 50%;
-      background: var(--accent);
-      position: relative;
-      box-shadow: 0 0 12px rgba(100, 215, 255, 0.7);
-    }
-
-    .pulse-dot::after {
-      content: "";
-      position: absolute;
-      inset: 0;
-      border-radius: inherit;
-      background: rgba(100, 215, 255, 0.4);
-      animation: pulse 2.8s ease-out infinite;
-    }
-
-    @keyframes pulse {
-      0% { transform: scale(0.6); opacity: 0.8; }
-      70% { transform: scale(1.8); opacity: 0; }
-      100% { transform: scale(1.8); opacity: 0; }
-    }
-
-    .integration-panel {
-      background: linear-gradient(140deg, rgba(24, 16, 56, 0.92), rgba(19, 20, 45, 0.86));
+    .post-card {
+      background: var(--surface-panel);
       border-radius: 20px;
-      border: 1px solid rgba(138, 43, 226, 0.42);
-      padding: 26px;
+      border: 1px solid rgba(100, 215, 255, 0.16);
+      padding: 24px;
       display: grid;
       gap: 18px;
       position: relative;
       overflow: hidden;
+      cursor: pointer;
+      transition: transform 0.28s ease, border-color 0.28s ease, box-shadow 0.28s ease;
     }
 
-    .integration-panel::after {
+    .post-card::before {
       content: "";
       position: absolute;
-      inset: 20% -20% -40% 30%;
-      background: radial-gradient(circle at center, rgba(138, 43, 226, 0.4), transparent 70%);
-      opacity: 0.7;
-      pointer-events: none;
+      inset: -40% 0 auto 40%;
+      height: 120%;
+      background: radial-gradient(circle at center, rgba(100, 215, 255, 0.28), transparent 70%);
+      opacity: 0;
+      transition: opacity 0.3s ease;
     }
 
-    .integration-panel__title {
+    .post-card:hover,
+    .post-card:focus-within {
+      transform: translateY(-6px);
+      border-color: rgba(138, 43, 226, 0.55);
+      box-shadow: 0 24px 36px rgba(18, 8, 44, 0.55);
+    }
+
+    .post-card:hover::before,
+    .post-card:focus-within::before {
+      opacity: 1;
+    }
+
+    .post-card__meta {
       display: flex;
-      flex-direction: column;
+      justify-content: space-between;
+      align-items: center;
+      font-size: 0.82rem;
+      color: var(--text-tertiary);
+      letter-spacing: 0.04em;
+    }
+
+    .post-card__meta strong {
+      color: var(--accent);
+      letter-spacing: 0.08em;
+    }
+
+    .post-card h3 {
+      font-size: 1.18rem;
+      line-height: 1.5;
+      letter-spacing: 0.04em;
+    }
+
+    .post-card p {
+      color: var(--text-secondary);
+      font-size: 0.94rem;
+      line-height: 1.7;
+    }
+
+    .post-card__footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 12px;
+      border-top: 1px solid rgba(100, 215, 255, 0.12);
+      padding-top: 14px;
+      font-size: 0.82rem;
+      color: var(--text-tertiary);
+    }
+
+    .post-card__tags {
+      display: flex;
+      flex-wrap: wrap;
       gap: 8px;
     }
 
-    .integration-panel__title span {
-      font-family: 'Orbitron', sans-serif;
-      letter-spacing: 0.32em;
-      font-size: 0.7rem;
-      color: rgba(177, 215, 255, 0.66);
-    }
-
-    .integration-panel__title h3 {
-      font-size: 1.28rem;
-      letter-spacing: 0.08em;
-    }
-
-    .integration-status {
-      display: grid;
-      gap: 16px;
-    }
-
-    .integration-status__item {
-      display: flex;
-      align-items: center;
-      justify-content: space-between;
-      gap: 16px;
-      padding: 14px 16px;
-      background: rgba(10, 15, 32, 0.7);
-      border-radius: 16px;
-      border: 1px solid rgba(100, 215, 255, 0.15);
-    }
-
-    .integration-status__item strong {
-      font-size: 0.92rem;
-      letter-spacing: 0.08em;
-    }
-
-    .status-pill {
+    .tag {
       display: inline-flex;
       align-items: center;
-      gap: 10px;
-      padding: 6px 14px;
+      gap: 6px;
+      padding: 4px 10px;
       border-radius: 999px;
-      font-size: 0.72rem;
-      letter-spacing: 0.14em;
+      background: rgba(100, 215, 255, 0.16);
+      color: var(--accent);
+      font-size: 0.74rem;
+      letter-spacing: 0.04em;
       text-transform: uppercase;
-      border: 1px solid rgba(100, 215, 255, 0.4);
-      color: rgba(204, 234, 255, 0.9);
-      background: rgba(17, 32, 52, 0.78);
     }
 
-    .status-pill[data-status="connected"] {
-      border-color: rgba(0, 212, 155, 0.8);
-      color: rgba(213, 255, 247, 0.92);
-      background: rgba(9, 42, 32, 0.85);
+    .post-card__stats {
+      display: flex;
+      gap: 14px;
     }
 
-    .status-pill[data-status="syncing"] {
-      border-color: rgba(100, 215, 255, 0.8);
-      background: rgba(14, 29, 50, 0.85);
-      color: rgba(214, 240, 255, 0.92);
+    .post-card__stats span {
+      display: inline-flex;
+      align-items: center;
+      gap: 4px;
     }
 
-    .status-pill[data-status="error"] {
-      border-color: rgba(255, 98, 126, 0.8);
-      background: rgba(54, 14, 26, 0.85);
-      color: rgba(255, 218, 228, 0.92);
+    .empty-state {
+      text-align: center;
+      padding: 60px 20px;
+      border: 1px dashed rgba(100, 215, 255, 0.25);
+      border-radius: 18px;
+      background: rgba(8, 12, 24, 0.6);
+      color: var(--text-secondary);
+      font-size: 0.96rem;
     }
 
-    .resource-list {
+    .back-btn {
+      align-self: flex-start;
+      background: rgba(100, 215, 255, 0.12);
+      border: 1px solid rgba(100, 215, 255, 0.35);
+      color: var(--text-primary);
+      padding: 10px 18px;
+      border-radius: 12px;
+      font-size: 0.86rem;
+      letter-spacing: 0.08em;
+      cursor: pointer;
+      transition: all 0.2s ease;
+    }
+
+    .back-btn:hover {
+      background: rgba(100, 215, 255, 0.22);
+      border-color: rgba(100, 215, 255, 0.5);
+    }
+
+    .post-detail {
+      background: var(--surface-panel-strong);
+      border-radius: 20px;
+      border: 1px solid rgba(138, 43, 226, 0.35);
+      padding: 34px;
+      display: grid;
+      gap: 24px;
+      position: relative;
+      overflow: hidden;
+    }
+
+    .post-detail::after {
+      content: "";
+      position: absolute;
+      inset: -40% 50% 10% -20%;
+      background: radial-gradient(circle at center, rgba(138, 43, 226, 0.45), transparent 70%);
+      opacity: 0.45;
+      pointer-events: none;
+    }
+
+    .post-detail__header {
       display: grid;
       gap: 12px;
-      margin-top: 6px;
+      position: relative;
+      z-index: 1;
     }
 
-    .resource-item {
+    .post-detail__category {
+      font-family: 'Orbitron', sans-serif;
+      letter-spacing: 0.24em;
+      font-size: 0.72rem;
+      text-transform: uppercase;
+      color: rgba(151, 211, 255, 0.72);
+    }
+
+    .post-detail__title {
+      font-size: clamp(1.8rem, 3vw, 2.4rem);
+      letter-spacing: 0.08em;
+      line-height: 1.4;
+    }
+
+    .post-detail__info {
       display: flex;
-      align-items: center;
-      gap: 14px;
-      font-size: 0.82rem;
+      flex-wrap: wrap;
+      gap: 18px;
+      font-size: 0.88rem;
+      color: var(--text-tertiary);
+      letter-spacing: 0.04em;
+    }
+
+    .post-detail__body {
+      position: relative;
+      z-index: 1;
       color: var(--text-secondary);
-      padding: 10px 0;
-      border-bottom: 1px solid rgba(100, 215, 255, 0.08);
+      line-height: 1.8;
+      font-size: 0.98rem;
+      display: grid;
+      gap: 16px;
     }
 
-    .resource-item:last-child {
-      border-bottom: none;
+    .post-detail__body h3 {
+      font-size: 1.18rem;
+      color: var(--text-primary);
+      letter-spacing: 0.06em;
+      margin-top: 12px;
     }
 
-    .resource-item svg {
-      width: 18px;
-      height: 18px;
-      color: rgba(100, 215, 255, 0.75);
-      flex-shrink: 0;
+    .post-detail__body ul {
+      margin-left: 18px;
+      display: grid;
+      gap: 8px;
     }
 
-    .resource-item a {
-      color: inherit;
-      text-decoration: none;
-      transition: color 0.25s ease;
+    .post-detail__footer {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      gap: 18px;
+      position: relative;
+      z-index: 1;
+      padding-top: 18px;
+      border-top: 1px solid rgba(100, 215, 255, 0.16);
     }
 
-    .resource-item a:hover,
-    .resource-item a:focus {
-      color: var(--accent);
+    .post-detail__tags {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+    }
+
+    .post-detail__interactions {
+      display: flex;
+      gap: 16px;
+      font-size: 0.86rem;
+      color: var(--text-tertiary);
     }
 
     @media (max-width: 1080px) {
-      .notice-board__body {
-        grid-template-columns: 1fr;
+      .method-forum__layout {
+        flex-direction: column;
       }
-      .board-controls {
-        align-items: flex-start;
+
+      .forum-sidebar {
         width: 100%;
+        border-right: none;
+        border-bottom: 1px solid rgba(100, 215, 255, 0.16);
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        gap: 28px;
       }
-      .board-filters {
-        justify-content: flex-start;
+
+      .forum-sidebar__header {
+        grid-column: 1 / -1;
       }
     }
 
@@ -541,17 +827,28 @@
       main {
         padding: 140px 18px 72px;
       }
-      .notice-board {
-        border-radius: 18px;
+
+      .forum-header__actions {
+        width: 100%;
+        align-items: flex-start;
       }
-      .board-title__desc {
-        font-size: 0.9rem;
+
+      .category-hero {
+        grid-template-columns: 1fr;
+        text-align: left;
       }
-      .method-card {
-        padding: 20px;
+
+      .category-hero__visual {
+        width: 84px;
+        height: 84px;
       }
-      .integration-panel {
-        padding: 22px;
+
+      .post-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .forum-sidebar {
+        grid-template-columns: 1fr;
       }
     }
   </style>
@@ -576,68 +873,116 @@
       <span class="hero__eyebrow">Method / Technique Notice Board</span>
       <h1 class="hero__title">METHOD</h1>
       <p class="hero__subtitle">
-        트레이딩 전략을 구성하는 모든 신호와 조합을 한 곳에서 관리합니다. 실시간 데이터베이스와 AWS S3 리소스를
-        연동해 분석 재료, 템플릿, 백테스트 리포트를 지속적으로 업데이트합니다.
+        트레이딩 전략을 구성하는 모든 신호와 조합을 한 곳에서 관리합니다. 지표 스택, 필터 조합, 백테스트 결과를
+        게시판 형태로 정리하여 언제든지 업데이트하고 공유할 수 있습니다.
       </p>
     </section>
 
-    <section class="notice-board" aria-labelledby="method-board">
-      <div class="notice-board__header">
-        <div class="board-title">
-          <span class="board-title__badge">[ notice board ]</span>
-          <h2 id="method-board" class="board-title__headline">Indicators &amp; Combinations</h2>
-          <p class="board-title__desc">
-            인디케이터 스택, 필터 조합, 백테스트 결과를 열람하고 필요한 자료를 바로 호출할 수 있도록 구성했습니다.
-            카테고리를 선택하면 관련 정보와 리소스를 빠르게 탐색할 수 있습니다.
-          </p>
-        </div>
-        <div class="board-controls">
-          <p class="board-updated" id="boardUpdated">Last sync — 준비 중</p>
-          <div class="board-filters" role="tablist" aria-label="Indicator filters">
-            <button type="button" class="active" data-filter="all">All</button>
-            <button type="button" data-filter="volume">Volume</button>
-            <button type="button" data-filter="trend">Moving Avg</button>
-            <button type="button" data-filter="price">Candlesticks</button>
-            <button type="button" data-filter="derivatives">Open Interest</button>
-            <button type="button" data-filter="oscillator">Oscillators</button>
-            <button type="button" data-filter="momentum">Momentum</button>
-            <button type="button" data-filter="volatility">Volatility</button>
-            <button type="button" data-filter="custom">Others</button>
+    <section class="method-forum" aria-labelledby="method-forum">
+      <div class="method-forum__layout">
+        <aside class="forum-sidebar">
+          <div class="forum-sidebar__header">
+            <span class="forum-sidebar__eyebrow">Indicator Library</span>
+            <h2 class="forum-sidebar__title">카테고리</h2>
+          </div>
+
+          <div class="category-group" data-group="indicators">
+            <p class="category-group__title">Indicators</p>
+            <ul class="category-nav" data-group-list="indicators"></ul>
+          </div>
+
+          <div class="category-group" data-group="combinations">
+            <p class="category-group__title">Combinations</p>
+            <ul class="category-nav" data-group-list="combinations"></ul>
+          </div>
+        </aside>
+
+        <div class="method-forum__main">
+          <div class="forum-view" id="boardView">
+            <header class="forum-header">
+              <div class="forum-header__info">
+                <span class="forum-header__badge" id="categoryBadge">VOLUME / 거래량</span>
+                <h2 class="forum-header__title" id="categoryTitle">Volume Indicators</h2>
+                <p class="forum-header__meta" id="categoryMeta">거래량 기반 지표로 시장의 압력과 강도를 읽어냅니다.</p>
+              </div>
+              <div class="forum-header__actions">
+                <p class="forum-sync" id="boardUpdated">Last sync — 준비 중</p>
+                <button class="new-post-btn" type="button" id="newPostButton">+ New Post</button>
+              </div>
+            </header>
+
+            <article class="category-hero" aria-live="polite">
+              <div class="category-hero__visual" id="categoryVisual">📊</div>
+              <div class="category-hero__text">
+                <h3 id="categoryOverlayTitle">거래량 지표</h3>
+                <p id="categoryOverlayDesc">거래량 흐름으로 시그널을 확인하고 다이버전스를 포착합니다.</p>
+              </div>
+            </article>
+
+            <section class="category-description">
+              <div class="description-header">
+                <h3>카테고리 개요</h3>
+                <button class="edit-description-btn" type="button" id="editDescriptionButton">설명 편집</button>
+              </div>
+              <div class="description-content" id="descriptionContent">
+                <p>거래량 기반 지표는 시장의 매수/매도 압력과 추세 강도를 파악하는 핵심 도구입니다. OBV, VWAP, 누적
+                  델타와 같은 시그널을 결합해 주요 전환 구간을 추적합니다.</p>
+              </div>
+              <div class="description-edit" id="descriptionEdit" hidden>
+                <textarea id="descriptionTextarea" placeholder="이 카테고리에 대한 설명을 작성해주세요..."></textarea>
+                <div class="edit-actions">
+                  <button class="btn btn-secondary" type="button" id="cancelDescriptionButton">취소</button>
+                  <button class="btn btn-primary" type="button" id="saveDescriptionButton">저장</button>
+                </div>
+              </div>
+            </section>
+
+            <form class="post-form" id="postForm" hidden>
+              <div class="form-group">
+                <label for="postTitle">제목</label>
+                <input type="text" id="postTitle" placeholder="게시글 제목을 입력하세요...">
+              </div>
+              <div class="form-group">
+                <label for="postCategory">카테고리</label>
+                <select id="postCategory"></select>
+              </div>
+              <div class="form-group">
+                <label for="postContent">내용</label>
+                <textarea id="postContent" placeholder="지표 설정, 전략 인사이트를 공유해주세요..."></textarea>
+              </div>
+              <div class="form-group">
+                <label for="postTags">태그 (쉼표로 구분)</label>
+                <input type="text" id="postTags" placeholder="예: OBV, Divergence, Momentum">
+              </div>
+              <div class="form-actions">
+                <button class="btn btn-secondary" type="button" id="cancelPostButton">취소</button>
+                <button class="btn btn-primary" type="submit">게시</button>
+              </div>
+            </form>
+
+            <div class="post-grid" id="postsList"></div>
+          </div>
+
+          <div class="forum-view" id="detailView" hidden>
+            <button class="back-btn" type="button" id="backToBoardButton">← 목록으로</button>
+            <article class="post-detail" id="postDetail">
+              <header class="post-detail__header">
+                <span class="post-detail__category" id="detailCategory">VOLUME</span>
+                <h2 class="post-detail__title" id="detailTitle">제목</h2>
+                <div class="post-detail__info">
+                  <span id="detailAuthor">Author</span>
+                  <span id="detailDate">방금 전</span>
+                  <span id="detailStats">👍 0 · 💬 0 · 👁 0</span>
+                </div>
+              </header>
+              <div class="post-detail__body" id="postDetailContent"></div>
+              <footer class="post-detail__footer">
+                <div class="post-detail__tags" id="postDetailTags"></div>
+                <div class="post-detail__interactions" id="postDetailInteractions"></div>
+              </footer>
+            </article>
           </div>
         </div>
-      </div>
-
-      <div class="notice-board__body">
-        <section class="board-section" aria-labelledby="indicator-section">
-          <h3 id="indicator-section" class="board-section__title">Indicators <small>기본 신호</small></h3>
-          <div class="card-grid" data-columns="2" id="indicatorGrid" role="list"></div>
-        </section>
-
-        <section class="board-section" aria-labelledby="combination-section">
-          <h3 id="combination-section" class="board-section__title">Combinations <small>전략 조합</small></h3>
-          <div class="card-grid" id="combinationGrid" role="list"></div>
-          <div class="integration-panel">
-            <div class="integration-panel__title">
-              <span>integration status</span>
-              <h3>DB &amp; AWS S3 연동 현황</h3>
-              <p class="board-title__desc" style="margin-top:4px;max-width:540px;">
-                실시간 시그널 데이터는 전용 API 데이터베이스에서, 전략 리포트와 리소스는 S3 버킷에서 불러옵니다.
-                연결 상태는 자동으로 모니터링되며 장애 시 알림이 표시됩니다.
-              </p>
-            </div>
-            <div class="integration-status">
-              <div class="integration-status__item" data-integration="db">
-                <strong>Trading DB</strong>
-                <span class="status-pill" data-status="pending">Sync 준비 중</span>
-              </div>
-              <div class="integration-status__item" data-integration="s3">
-                <strong>AWS S3 Resources</strong>
-                <span class="status-pill" data-status="pending">Sync 준비 중</span>
-              </div>
-            </div>
-            <div class="resource-list" id="resourceList" aria-live="polite"></div>
-          </div>
-        </section>
       </div>
     </section>
   </main>

--- a/apps/web/menu/method/method.js
+++ b/apps/web/menu/method/method.js
@@ -1,400 +1,613 @@
-const API_BASE = '/api/method';
-
-const clone = value => (typeof structuredClone === 'function' ? structuredClone(value) : JSON.parse(JSON.stringify(value)));
-
-const fallbackBoard = {
+const forumData = {
   updatedAt: new Date().toISOString(),
-  indicators: [
+  categories: [
     {
-      slug: 'volume-depth',
-      label: '-Volume-',
-      title: '거래량 심도 & 누적 흐름',
-      description: '현물 · 선물 거래량을 통합해 강도, 누적 델타를 추적합니다.',
-      highlights: [
-        '거래소별 실시간 체결 집계',
-        '세션 구간별 누적 델타/OBV',
-        '고래·기관 지갑 흐름 연동'
-      ],
-      status: { state: 'pending', label: 'DB 연동 대기', source: 'db' },
-      filter: 'volume'
+      id: 'volume',
+      group: 'indicators',
+      title: 'Volume Indicators',
+      label: '거래량',
+      badge: 'VOLUME / 거래량',
+      meta: '거래량 흐름과 누적 델타로 강도와 다이버전스를 추적합니다.',
+      heroIcon: '📊',
+      overlayTitle: '거래량 지표',
+      overlayDescription: '거래량 기반 데이터로 매수·매도 압력과 추세 강도를 확인합니다.',
+      description:
+        '거래량 기반 지표는 시장의 매수/매도 압력과 추세 강도를 파악하는 핵심 도구입니다. OBV, VWAP, 누적 델타와 같은 시그널을 결합해 주요 전환 구간을 추적합니다.'
     },
     {
-      slug: 'moving-average-suite',
-      label: '-Moving Averages-',
-      title: '트렌드 밴드 & 적응형 평균',
-      description: '멀티 타임프레임 EMA/SMA와 적응형 MA로 추세 밴드를 구성합니다.',
-      highlights: [
-        'HTF/LTF 멀티 레이어 추세 지도',
-        'KAMA · HMA · WMA 혼합 필터',
-        '크로스오버 이벤트 자동 라벨링'
-      ],
-      status: { state: 'pending', label: '시그널 정렬 중', source: 'db' },
-      filter: 'trend'
+      id: 'moving-averages',
+      group: 'indicators',
+      title: 'Moving Average Indicators',
+      label: '이동평균',
+      badge: 'TREND / 이동평균',
+      meta: '평균값 밴드와 적응형 추세 지표로 방향성을 정의합니다.',
+      heroIcon: '📈',
+      overlayTitle: '이동평균 지표',
+      overlayDescription: 'EMA, SMA, 적응형 평균을 조합해 다중 타임프레임 추세를 분석합니다.',
+      description:
+        '이동평균 지표는 가격 데이터를 평활화하여 추세를 파악하고 지지/저항대를 설정합니다. EMA, SMA, KAMA 등의 평균값과 밴드형 지표를 활용해 시장 구조를 해석합니다.'
     },
     {
-      slug: 'candlestick-lab',
-      label: '-Candlesticks-',
-      title: '캔들 패턴 라이브러리',
-      description: '패턴과 거래량, 시장 미세구조 데이터를 결합해 컨텍스트를 제공합니다.',
-      highlights: [
-        'AI 패턴 스코어 · 확률 매핑',
-        '볼륨 컨펌 / 라인 브레이크 감시',
-        '세션 이벤트 주석 자동화'
-      ],
-      status: { state: 'pending', label: '패턴 피드 연결 대기', source: 'db' },
-      filter: 'price'
+      id: 'candlesticks',
+      group: 'indicators',
+      title: 'Candlestick Patterns',
+      label: '캔들스틱',
+      badge: 'PRICE ACTION / 패턴',
+      meta: '캔들 구조, FVG, 오더블록 등을 기반으로 맥락을 읽어냅니다.',
+      heroIcon: '🕯️',
+      overlayTitle: '캔들 패턴 분석',
+      overlayDescription: '가격 패턴과 체결 흐름을 결합해 전환 구간과 유동성 영역을 탐지합니다.',
+      description:
+        '캔들스틱 카테고리는 패턴과 체결량, 시장 미세구조 데이터를 결합해 컨텍스트를 제공합니다. FVG, 오더블록, 유동성 풀을 추적해 매매 시나리오를 정리합니다.'
     },
     {
-      slug: 'open-interest-monitor',
-      label: '-Open Interest-',
-      title: 'OI 변동 & 파생상품 감시',
-      description: '선물 미결제약정, 펀딩, 베이시스 데이터를 통합해 레버리지 포지션을 추적합니다.',
-      highlights: [
-        '거래소별 롱/숏 비율 디컴포즈',
-        '펀딩레이트 과열 구간 알림',
-        '커브 구조(Contango/Backwardation) 시각화'
-      ],
-      status: { state: 'pending', label: 'Derivatives API 연결 중', source: 'db' },
-      filter: 'derivatives'
+      id: 'open-interest',
+      group: 'indicators',
+      title: 'Open Interest Analysis',
+      label: '미결제약정',
+      badge: 'DERIVATIVES / OI',
+      meta: '선물/옵션 포지션 변화를 추적해 레버리지 흐름을 확인합니다.',
+      heroIcon: '🧭',
+      overlayTitle: '미결제약정 분석',
+      overlayDescription: 'OI, 펀딩비, 베이시스 데이터를 통합해 파생상품 포지션을 추적합니다.',
+      description:
+        '미결제약정 지표는 선물과 옵션 포지션 변화를 분석하여 레버리지 흐름을 파악합니다. 펀딩비, 베이시스, 롱/숏 비율을 통합해 고래 포지션을 모니터링합니다.'
     },
     {
-      slug: 'oscillator-suite',
-      label: '-Oscillators-',
-      title: '사이클 스캐너',
-      description: 'RSI, Stochastic, MACD 등 변동성 조정 오실레이터를 묶어 과매수/과매도 구간을 탐지합니다.',
-      highlights: [
-        'EMA 평활화된 RSI 히트맵',
-        '디버전스 자동 태깅',
-        '미세 사이클 위상 정렬'
-      ],
-      status: { state: 'pending', label: '오실레이터 세트 로딩', source: 'db' },
-      filter: 'oscillator'
+      id: 'oscillators',
+      group: 'indicators',
+      title: 'Oscillator Indicators',
+      label: '오실레이터',
+      badge: 'OSCILLATOR / 사이클',
+      meta: '상대적 강도와 과매수/과매도 구간을 정밀 탐지합니다.',
+      heroIcon: '⚡',
+      overlayTitle: '오실레이터 지표',
+      overlayDescription: 'RSI, Stochastic 등 범위 기반 지표로 사이클 전환을 포착합니다.',
+      description:
+        '오실레이터 지표는 RSI, Stochastic, MACD 등 범위 기반 도구로 과매수/과매도 영역을 판단하고 추세 전환을 예측합니다. 변동성 조정과 디버전스 탐지를 병행합니다.'
     },
     {
-      slug: 'momentum-engine',
-      label: '-Momentum-',
-      title: '모멘텀 & 추세 힘 지수',
-      description: 'ROC, CCI, DMI를 혼합한 맞춤형 모멘텀 스코어를 제공합니다.',
-      highlights: [
-        '레이더 차트 기반 스코어 보드',
-        '타임 디케이 기반 랭킹',
-        '이벤트 트리거 알림'
-      ],
-      status: { state: 'pending', label: '랭킹 메트릭 계산 중', source: 'db' },
-      filter: 'momentum'
+      id: 'momentum',
+      group: 'indicators',
+      title: 'Momentum Indicators',
+      label: '모멘텀',
+      badge: 'MOMENTUM / 속도',
+      meta: '가격 변화율과 추세의 가속도를 계량화합니다.',
+      heroIcon: '🚀',
+      overlayTitle: '모멘텀 지표',
+      overlayDescription: 'ROC, CCI, DMI 등 속도 기반 지표로 추세의 힘을 측정합니다.',
+      description:
+        '모멘텀 지표는 가격 변화 속도와 가속도를 측정해 추세 지속 여부를 판단합니다. ROC, CCI, DMI 기반의 커스텀 스코어링으로 랭킹을 구성합니다.'
     },
     {
-      slug: 'volatility-lab',
-      label: '-Volatility-',
-      title: '변동성 공명 실험실',
-      description: 'ATR, HV, 옵션 IV를 통합한 변동성 클러스터 분석.',
-      highlights: [
-        '스파이크/드롭 감지',
-        '옵션 히스토리컬 vs. 임플라이드 비교',
-        '공포/탐욕 밴드 추적'
-      ],
-      status: { state: 'pending', label: 'Volatility feed 준비 중', source: 'db' },
-      filter: 'volatility'
+      id: 'volatility',
+      group: 'indicators',
+      title: 'Volatility Indicators',
+      label: '변동성',
+      badge: 'VOLATILITY / 리스크',
+      meta: 'ATR, HV, 옵션 IV 지표로 변동성 클러스터를 분석합니다.',
+      heroIcon: '🌊',
+      overlayTitle: '변동성 지표',
+      overlayDescription: '시장 변동성과 분산을 계량화하여 돌파 구간과 리스크를 평가합니다.',
+      description:
+        '변동성 지표는 ATR, HV, 옵션 IV 데이터를 결합하여 변동성 클러스터와 스파이크/드롭 구간을 탐지합니다. 리스크 관리와 포지션 사이징에 활용합니다.'
     },
     {
-      slug: 'custom-lab',
-      label: '-Others-',
-      title: '커스텀 실험 모듈',
-      description: '온체인, 소셜, 거시 데이터를 결합한 맞춤형 실험 공간입니다.',
-      highlights: [
-        '온체인 플로우 / 토큰 로테이션',
-        '뉴스 감성 지표 및 AI 스코어',
-        '거시 이벤트 대비 시나리오'
-      ],
-      status: { state: 'pending', label: '외부 데이터 브리지 동기화', source: 'db' },
-      filter: 'custom'
+      id: 'others',
+      group: 'indicators',
+      title: 'Other Indicators',
+      label: '기타',
+      badge: 'CUSTOM / 실험실',
+      meta: '온체인, 거시, AI 기반 실험 지표를 정리합니다.',
+      heroIcon: '🧪',
+      overlayTitle: '커스텀 실험 모듈',
+      overlayDescription: '온체인·거시·AI 시그널을 결합한 실험적 지표를 아카이브합니다.',
+      description:
+        '기타 카테고리는 온체인, 거시, AI 분석 등 표준 분류를 벗어난 지표를 수집합니다. 실험적 접근과 시나리오 기반 분석을 기록합니다.'
+    },
+    {
+      id: 'multi-indicator',
+      group: 'combinations',
+      title: 'Multi-Indicator Setups',
+      label: '다중지표',
+      badge: 'STACK / PRESET',
+      meta: '볼륨-추세-모멘텀 스택을 프리셋으로 정리합니다.',
+      heroIcon: '🛰️',
+      overlayTitle: '다중지표 프리셋',
+      overlayDescription: '여러 지표를 조합해 조건부 시그널 체인을 구축합니다.',
+      description:
+        '다중지표 프리셋은 볼륨, 추세, 모멘텀 지표를 조합해 특정 시나리오를 자동으로 감시합니다. 조건부 알림과 시그널 필터링 로직을 정리합니다.'
+    },
+    {
+      id: 'signal-filters',
+      group: 'combinations',
+      title: 'Signal Filters',
+      label: '시그널 필터',
+      badge: 'FILTER / NOISE CONTROL',
+      meta: '시그널 노이즈를 제거해 정확도를 높입니다.',
+      heroIcon: '🎯',
+      overlayTitle: '시그널 필터 체계',
+      overlayDescription: '시장 구조와 히스테리시스를 활용해 거짓 시그널을 줄입니다.',
+      description:
+        '시그널 필터 카테고리는 시장 구조, 히스테리시스, 변동성 필터를 이용해 거짓 시그널을 제거합니다. 각 필터 체인의 성능과 적용 사례를 정리합니다.'
+    },
+    {
+      id: 'backtest',
+      group: 'combinations',
+      title: 'Backtest Results & Analysis',
+      label: '백테스트',
+      badge: 'BACKTEST / PERFORMANCE',
+      meta: '성과 지표와 리스크 프로파일을 수치화합니다.',
+      heroIcon: '📚',
+      overlayTitle: '백테스트 리포트',
+      overlayDescription: '전략별 성과지표와 시뮬레이션 로그를 기록합니다.',
+      description:
+        '백테스트 카테고리는 전략별 성과 지표, 드로다운, 워킹/포워드 테스트 로그를 아카이브합니다. 데이터 소스와 S3 리포트를 연결할 수 있도록 구성했습니다.'
     }
   ],
-  combinations: [
+  posts: [
     {
-      slug: 'multi-indicator-setup',
-      label: 'Multi-Indicator Setup',
-      title: '멀티 레이어 시그널 세트',
-      description: '인디케이터 묶음을 프리셋으로 저장하고, 상황별 최적화된 시나리오를 제공합니다.',
-      highlights: [
-        '볼륨 + 추세 + 오실레이터 동시 확인',
-        '조건부 알림 / 시나리오 플래너',
-        '리밸런싱 히스토리 추적'
-      ],
-      status: { state: 'pending', label: 'Preset 업데이트 예정', source: 'db' },
-      filters: ['volume', 'trend', 'oscillator']
+      id: 'p-volume-1',
+      category: 'volume',
+      hero: '📈',
+      title: 'OBV + Price Divergence Strategy',
+      excerpt:
+        'OBV와 가격 다이버전스를 결합해 중기 추세에서 높은 승률을 기록한 전략입니다. 타임프레임별 최적 설정값과 필수 확인 지표를 정리했습니다.',
+      content: `
+        <h3>개요</h3>
+        <p>On-Balance Volume (OBV)와 가격 다이버전스를 결합한 전략입니다. 특히 4H~12H 구간에서 신뢰도가 높으며, 거래량이 동반되지 않는 가격 움직임을 필터링합니다.</p>
+        <h3>설정 방법</h3>
+        <ul>
+          <li>OBV 지표에 21EMA를 적용해 기울기를 확인합니다.</li>
+          <li>가격과 OBV의 다이버전스가 발생할 때 RSI(14)로 추가 컨펌을 진행합니다.</li>
+          <li>누적 델타와 거래량 프로파일로 주요 레벨을 체크합니다.</li>
+        </ul>
+        <h3>진입 조건</h3>
+        <p>가격이 상승하지만 OBV는 하락하는 베어리시 다이버전스가 발생하고, RSI가 70 이상에서 하락 전환할 때 숏 진입을 고려합니다. 반대 시나리오로는 롱 포지션을 구성합니다.</p>
+        <h3>리스크 관리</h3>
+        <p>손절선은 진입가 기준 2% 상단에, 익절은 최소 1:2 비율로 설정합니다. 거래량이 평균 대비 120% 이상일 때만 시그널을 채택합니다.</p>
+        <h3>백테스트 결과</h3>
+        <p>최근 6개월간 승률 68%, 평균 수익률 3.2%, 최대 드로다운 6.5%를 기록했습니다.</p>
+      `,
+      author: 'SuperSmoother',
+      created: '2시간 전',
+      stats: { likes: 24, comments: 8, views: 156 },
+      tags: ['OBV', 'Divergence', 'Volume Analysis']
     },
     {
-      slug: 'signal-filters',
-      label: 'Signal Filters',
-      title: '시그널 필터 체계',
-      description: '거짓 시그널 제거를 위한 필터 체인을 구성하고 성능을 검증합니다.',
-      highlights: [
-        '시장 구조 Breaker 감지',
-        '히스테리시스 기반 필터',
-        'P&L 충격 분석 리포트'
-      ],
-      status: { state: 'pending', label: '필터 체인 설계 중', source: 'db' },
-      filters: ['price', 'momentum', 'oscillator']
+      id: 'p-moving-1',
+      category: 'moving-averages',
+      hero: '📊',
+      title: 'Specter Trend Cloud [ChartPrime]',
+      excerpt:
+        '이동평균 기반 트렌드 클라우드로 추세와 변곡점을 동시에 감지합니다. 색상 밴드와 알림 로직을 커스터마이즈했습니다.',
+      content: `
+        <h3>구성</h3>
+        <p>Specter Trend Cloud는 EMA 34/55 기반의 코어 밴드와 HMA 필터를 결합합니다. 구름 색상은 추세 강도에 따라 단계적으로 변환됩니다.</p>
+        <h3>활용법</h3>
+        <ul>
+          <li>클라우드 외부에서 가격이 유지되는지로 추세 지속 여부를 판단합니다.</li>
+          <li>클라우드 내부 재진입 시 거래량과 오실레이터 컨펌을 요구합니다.</li>
+          <li>거래량이 평균 대비 80% 미만일 때는 신호를 무시합니다.</li>
+        </ul>
+        <h3>추가 설정</h3>
+        <p>멀티 타임프레임 EMA와 VWAP 레벨을 추가해 추세 방향과 유동성 레벨을 동시에 확인합니다.</p>
+      `,
+      author: 'ChartPrime',
+      created: '5시간 전',
+      stats: { likes: 67, comments: 12, views: 234 },
+      tags: ['Trend Cloud', 'Moving Average']
     },
     {
-      slug: 'backtest-results',
-      label: 'Backtest Results',
-      title: '백테스트 리포트',
-      description: 'AWS S3에서 전략별 리포트를 불러와 성과를 검증하고 배포합니다.',
-      highlights: [
-        '전략별 KPI & 드로다운 테이블',
-        '워킹/포워드 테스트 전환 로그',
-        'S3 리포트 자동 보존 정책'
-      ],
-      status: { state: 'pending', label: 'S3 리소스 연결 대기', source: 's3' },
-      filters: ['volatility', 'trend', 'custom']
-    }
-  ],
-  integrations: {
-    db: { state: 'pending', label: 'Sync 준비 중' },
-    s3: { state: 'pending', label: 'Sync 준비 중' }
-  },
-  resources: [
-    {
-      title: 'Two.4 Strategy Blueprint (샘플)',
-      href: '#',
-      meta: 'PDF · 1.2MB · AWS S3',
-      source: 's3'
+      id: 'p-oscillator-1',
+      category: 'oscillators',
+      hero: '⚡',
+      title: 'Momentum Shift Oscillator (MSO)',
+      excerpt:
+        'RSI, ROC, MACD의 장점을 합친 커스텀 오실레이터입니다. 위상 변화와 디버전스를 자동 태깅합니다.',
+      content: `
+        <h3>핵심 아이디어</h3>
+        <p>RSI 21, ROC 9, MACD(12, 26, 9)를 결합해 시그널 라인을 생성합니다. 위상 변화가 발생하면 색상과 알림이 동시에 전송됩니다.</p>
+        <h3>세부 설정</h3>
+        <ul>
+          <li>RSI는 EMA 3으로 추가 평활화합니다.</li>
+          <li>ROC는 절대값 2.5 이상에서 강한 모멘텀으로 표시합니다.</li>
+          <li>MACD 히스토그램이 0을 돌파할 때만 주요 신호를 허용합니다.</li>
+        </ul>
+        <h3>검증</h3>
+        <p>비트코인 4H 차트에서 1년간 백테스트한 결과 승률 63%, 평균 R/R 1:2.6을 기록했습니다.</p>
+      `,
+      author: 'SharpStat',
+      created: '1일 전',
+      stats: { likes: 143, comments: 28, views: 892 },
+      tags: ['Oscillator', 'Momentum', 'Custom']
     },
     {
-      title: 'Indicator Stack Template (샘플)',
-      href: '#',
-      meta: 'JSON · 38KB · DB Export',
-      source: 'db'
+      id: 'p-combination-1',
+      category: 'multi-indicator',
+      hero: '🔥',
+      title: 'NEXUS - SPA Strategy',
+      excerpt:
+        'Shadow Portfolio Adaptive 프레임워크로 볼륨·추세·심리 지표를 묶은 전략입니다. 조건부 가중치를 적용합니다.',
+      content: `
+        <h3>전략 구조</h3>
+        <p>볼륨(누적 델타), 추세(Adaptive MA), 심리(볼륨 가중 RSI)를 결합한 3중 필터 전략입니다.</p>
+        <h3>진입 규칙</h3>
+        <ul>
+          <li>세 필터 중 최소 두 가지가 동일 방향일 때만 진입합니다.</li>
+          <li>포지션 사이즈는 신뢰도 스코어에 따라 0.5~1.5%로 조절합니다.</li>
+          <li>백테스트 기준, 평단 대비 3% 역행 시 손절 처리합니다.</li>
+        </ul>
+        <h3>성과</h3>
+        <p>12개월 백테스트 결과 CAGR 38%, 최대 드로다운 7.8%, 승률 61%를 기록했습니다.</p>
+      `,
+      author: 'INFLECTION',
+      created: '2일 전',
+      stats: { likes: 89, comments: 15, views: 445 },
+      tags: ['Strategy', 'Portfolio', 'Adaptive']
+    },
+    {
+      id: 'p-other-1',
+      category: 'others',
+      hero: '🎯',
+      title: 'Institutional Levels (CNN)',
+      excerpt:
+        'CNN 기반으로 기관 매물대를 추정하는 실험 지표입니다. 자동화된 구역 감지와 백테스트 로그를 공유합니다.',
+      content: `
+        <h3>알고리즘 개요</h3>
+        <p>거래량 프로파일, 체결 강도, 파생상품 데이터를 입력값으로 사용하는 1D CNN 네트워크를 구성했습니다.</p>
+        <h3>출력</h3>
+        <p>구역별 확률 스코어와 신뢰도를 0~1 사이로 출력하며, 상위 10% 구간만 차트에 표시합니다.</p>
+        <h3>활용 전략</h3>
+        <p>추세 추종 전략과 병행 시 손익비가 개선되며, 기관 물량 추적용으로 활용할 수 있습니다.</p>
+      `,
+      author: 'PhenLab',
+      created: '3일 전',
+      stats: { likes: 201, comments: 45, views: 1200 },
+      tags: ['AI', 'Neural Network', 'Institutional']
+    },
+    {
+      id: 'p-volatility-1',
+      category: 'volatility',
+      hero: '🌊',
+      title: 'Mean Reversion Probability Zones',
+      excerpt:
+        '평균 회귀 확률을 구간화하여 변동성에 따른 포지션 스케일링 전략을 제공합니다.',
+      content: `
+        <h3>지표 구조</h3>
+        <p>ATR 기반 밴드와 히스토리컬 볼래틸리티를 결합해 확률 구간을 산출합니다. 가격이 상단 밴드에서 유지될수록 회귀 확률이 감소합니다.</p>
+        <h3>활용법</h3>
+        <ul>
+          <li>확률 70% 이상 구간에서 역추세 스캘핑을 고려합니다.</li>
+          <li>포지션 규모는 확률 * 변동성 스코어로 조정합니다.</li>
+          <li>트레일링 스탑은 VWAP ± ATR(2)로 설정합니다.</li>
+        </ul>
+      `,
+      author: 'BigBeluga',
+      created: '1주 전',
+      stats: { likes: 156, comments: 32, views: 678 },
+      tags: ['Mean Reversion', 'Probability', 'Zones']
     }
   ]
 };
 
-const integrationLabels = {
-  connected: 'Connected',
-  syncing: 'Syncing',
-  pending: 'Sync 준비 중',
-  error: 'Error'
+const state = {
+  currentCategory: forumData.categories[0]?.id ?? 'volume',
+  posts: [...forumData.posts],
+  descriptions: Object.fromEntries(forumData.categories.map(category => [category.id, category.description]))
 };
+
+const elements = {
+  boardView: document.getElementById('boardView'),
+  detailView: document.getElementById('detailView'),
+  categoryBadge: document.getElementById('categoryBadge'),
+  categoryTitle: document.getElementById('categoryTitle'),
+  categoryMeta: document.getElementById('categoryMeta'),
+  categoryVisual: document.getElementById('categoryVisual'),
+  categoryOverlayTitle: document.getElementById('categoryOverlayTitle'),
+  categoryOverlayDesc: document.getElementById('categoryOverlayDesc'),
+  descriptionContent: document.getElementById('descriptionContent'),
+  descriptionEdit: document.getElementById('descriptionEdit'),
+  descriptionTextarea: document.getElementById('descriptionTextarea'),
+  postsList: document.getElementById('postsList'),
+  postForm: document.getElementById('postForm'),
+  postCategory: document.getElementById('postCategory'),
+  postTitle: document.getElementById('postTitle'),
+  postContent: document.getElementById('postContent'),
+  postTags: document.getElementById('postTags'),
+  newPostButton: document.getElementById('newPostButton'),
+  cancelPostButton: document.getElementById('cancelPostButton'),
+  editDescriptionButton: document.getElementById('editDescriptionButton'),
+  cancelDescriptionButton: document.getElementById('cancelDescriptionButton'),
+  saveDescriptionButton: document.getElementById('saveDescriptionButton'),
+  boardUpdated: document.getElementById('boardUpdated'),
+  backToBoardButton: document.getElementById('backToBoardButton'),
+  detailCategory: document.getElementById('detailCategory'),
+  detailTitle: document.getElementById('detailTitle'),
+  detailAuthor: document.getElementById('detailAuthor'),
+  detailDate: document.getElementById('detailDate'),
+  detailStats: document.getElementById('detailStats'),
+  postDetailContent: document.getElementById('postDetailContent'),
+  postDetailTags: document.getElementById('postDetailTags'),
+  postDetailInteractions: document.getElementById('postDetailInteractions')
+};
+
+const groupLists = Array.from(document.querySelectorAll('[data-group-list]')).reduce((acc, element) => {
+  acc[element.dataset.groupList] = element;
+  return acc;
+}, {});
 
 function formatUpdatedAt(timestamp) {
   if (!timestamp) return 'Last sync — 준비 중';
   try {
     const date = new Date(timestamp);
     if (Number.isNaN(date.getTime())) return 'Last sync — 준비 중';
-    const formatted = new Intl.DateTimeFormat('ko-KR', {
+    return `Last sync — ${new Intl.DateTimeFormat('ko-KR', {
       year: 'numeric',
       month: '2-digit',
       day: '2-digit',
       hour: '2-digit',
       minute: '2-digit'
-    }).format(date);
-    return `Last sync — ${formatted}`;
+    }).format(date)}`;
   } catch (error) {
     return 'Last sync — 준비 중';
   }
 }
 
-function createList(items = []) {
-  const list = document.createElement('ul');
-  list.className = 'method-card__list';
-  items.forEach(text => {
-    const li = document.createElement('li');
-    li.textContent = text;
-    list.appendChild(li);
+function renderCategories() {
+  forumData.categories.forEach(category => {
+    const list = groupLists[category.group];
+    if (!list) return;
+    const listItem = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = category.title;
+    button.dataset.id = category.id;
+    button.dataset.label = category.label;
+    button.addEventListener('click', () => selectCategory(category.id));
+    listItem.appendChild(button);
+    list.appendChild(listItem);
   });
-  return list;
 }
 
-function createCard(item) {
-  const article = document.createElement('article');
-  article.className = 'method-card';
-  article.dataset.group = item.filter || 'all';
-  article.setAttribute('role', 'listitem');
-
-  const label = document.createElement('span');
-  label.className = 'method-card__label';
-  label.textContent = item.label;
-
-  const title = document.createElement('h4');
-  title.className = 'method-card__title';
-  title.textContent = item.title;
-
-  const meta = document.createElement('p');
-  meta.className = 'method-card__meta';
-  meta.textContent = item.description;
-
-  article.appendChild(label);
-  article.appendChild(title);
-  article.appendChild(meta);
-  article.appendChild(createList(item.highlights));
-
-  if (item.status) {
-    const status = document.createElement('div');
-    status.className = 'method-card__status';
-    status.innerHTML = `<span class="pulse-dot" aria-hidden="true"></span>${item.status.label}`;
-    status.dataset.source = item.status.source || 'db';
-    article.appendChild(status);
-  }
-
-  return article;
+function populateCategorySelect() {
+  if (!elements.postCategory) return;
+  elements.postCategory.innerHTML = '';
+  forumData.categories.forEach(category => {
+    const option = document.createElement('option');
+    option.value = category.id;
+    option.textContent = category.title;
+    elements.postCategory.appendChild(option);
+  });
 }
 
-function createComboCard(item) {
-  const card = createCard(item);
-  if (item.filters) {
-    card.dataset.groups = item.filters.join(',');
+function selectCategory(categoryId) {
+  state.currentCategory = categoryId;
+  if (!elements.descriptionEdit.hasAttribute('hidden')) {
+    closeDescriptionEditor();
   }
+  updateActiveCategory();
+  updateCategoryHeader();
+  updateDescription();
+  renderPosts();
+  if (elements.postCategory) {
+    elements.postCategory.value = categoryId;
+  }
+}
+
+function updateActiveCategory() {
+  document.querySelectorAll('.category-nav button').forEach(button => {
+    button.classList.toggle('active', button.dataset.id === state.currentCategory);
+  });
+}
+
+function updateCategoryHeader() {
+  const category = forumData.categories.find(item => item.id === state.currentCategory);
+  if (!category) return;
+  elements.categoryBadge.textContent = category.badge;
+  elements.categoryTitle.textContent = category.title;
+  elements.categoryMeta.textContent = category.meta;
+  elements.categoryVisual.textContent = category.heroIcon;
+  elements.categoryOverlayTitle.textContent = category.overlayTitle;
+  elements.categoryOverlayDesc.textContent = category.overlayDescription;
+}
+
+function updateDescription() {
+  const description = state.descriptions[state.currentCategory] ?? '';
+  elements.descriptionContent.innerHTML = description ? `<p>${description}</p>` : '<p>이 카테고리에 대한 설명을 작성해주세요.</p>';
+  if (!elements.descriptionEdit.hasAttribute('hidden')) {
+    elements.descriptionTextarea.value = description;
+  }
+}
+
+function renderPosts() {
+  if (!elements.postsList) return;
+  elements.postsList.innerHTML = '';
+  const posts = state.posts.filter(post => post.category === state.currentCategory);
+  if (posts.length === 0) {
+    const empty = document.createElement('div');
+    empty.className = 'empty-state';
+    empty.textContent = '아직 등록된 게시글이 없습니다. 첫 번째 전략을 공유해보세요!';
+    elements.postsList.appendChild(empty);
+    return;
+  }
+  posts.forEach(post => {
+    elements.postsList.appendChild(createPostCard(post));
+  });
+}
+
+function createPostCard(post) {
+  const card = document.createElement('article');
+  card.className = 'post-card';
+  card.tabIndex = 0;
+
+  const meta = document.createElement('div');
+  meta.className = 'post-card__meta';
+  const author = document.createElement('strong');
+  author.textContent = post.author;
+  const time = document.createElement('span');
+  time.textContent = post.created;
+  meta.append(author, time);
+
+  const title = document.createElement('h3');
+  title.textContent = post.title;
+
+  const excerpt = document.createElement('p');
+  excerpt.textContent = post.excerpt;
+
+  const footer = document.createElement('div');
+  footer.className = 'post-card__footer';
+
+  const tags = document.createElement('div');
+  tags.className = 'post-card__tags';
+  post.tags.forEach(tag => {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.textContent = tag;
+    tags.appendChild(span);
+  });
+
+  const stats = document.createElement('div');
+  stats.className = 'post-card__stats';
+  stats.innerHTML = `<span>👍 ${post.stats.likes}</span><span>💬 ${post.stats.comments}</span><span>👁 ${post.stats.views}</span>`;
+
+  footer.append(tags, stats);
+  card.append(meta, title, excerpt, footer);
+
+  card.addEventListener('click', () => openPostDetail(post.id));
+  card.addEventListener('keypress', event => {
+    if (event.key === 'Enter') {
+      openPostDetail(post.id);
+    }
+  });
+
   return card;
 }
 
-function applyBoardData(board) {
-  const indicatorGrid = document.getElementById('indicatorGrid');
-  const combinationGrid = document.getElementById('combinationGrid');
-  const boardUpdated = document.getElementById('boardUpdated');
-
-  indicatorGrid.innerHTML = '';
-  combinationGrid.innerHTML = '';
-
-  board.indicators.forEach(entry => {
-    indicatorGrid.appendChild(createCard(entry));
+function openPostDetail(postId) {
+  const post = state.posts.find(item => item.id === postId);
+  if (!post) return;
+  const category = forumData.categories.find(item => item.id === post.category);
+  elements.detailCategory.textContent = category ? category.badge : 'METHOD';
+  elements.detailTitle.textContent = post.title;
+  elements.detailAuthor.textContent = post.author;
+  elements.detailDate.textContent = post.created;
+  elements.detailStats.textContent = `👍 ${post.stats.likes} · 💬 ${post.stats.comments} · 👁 ${post.stats.views}`;
+  elements.postDetailContent.innerHTML = post.content;
+  elements.postDetailTags.innerHTML = '';
+  post.tags.forEach(tag => {
+    const span = document.createElement('span');
+    span.className = 'tag';
+    span.textContent = tag;
+    elements.postDetailTags.appendChild(span);
   });
-
-  board.combinations.forEach(entry => {
-    combinationGrid.appendChild(createComboCard(entry));
-  });
-
-  boardUpdated.textContent = formatUpdatedAt(board.updatedAt);
+  elements.postDetailInteractions.innerHTML = `
+    <span>좋아요 ${post.stats.likes}</span>
+    <span>댓글 ${post.stats.comments}</span>
+    <span>조회수 ${post.stats.views}</span>
+  `;
+  elements.boardView.hidden = true;
+  elements.detailView.hidden = false;
 }
 
-function updateIntegrationStatus(key, payload) {
-  const row = document.querySelector(`.integration-status__item[data-integration="${key}"]`);
-  if (!row) return;
-  const pill = row.querySelector('.status-pill');
-  if (!pill) return;
-  const state = payload?.state || 'pending';
-  const label = payload?.label || integrationLabels[state] || integrationLabels.pending;
-  pill.dataset.status = state;
-  pill.textContent = label;
+function closePostDetail() {
+  elements.detailView.hidden = true;
+  elements.boardView.hidden = false;
 }
 
-function renderResources(resources = []) {
-  const list = document.getElementById('resourceList');
-  if (!list) return;
-  list.innerHTML = '';
+function togglePostForm(forceState) {
+  if (!elements.postForm) return;
+  const shouldOpen = typeof forceState === 'boolean' ? forceState : elements.postForm.hasAttribute('hidden');
+  if (shouldOpen) {
+    elements.postForm.removeAttribute('hidden');
+    elements.newPostButton.textContent = '− Close';
+    elements.postTitle.focus();
+  } else {
+    elements.postForm.setAttribute('hidden', '');
+    elements.newPostButton.textContent = '+ New Post';
+  }
+}
 
-  if (!resources.length) {
-    const empty = document.createElement('p');
-    empty.className = 'board-title__desc';
-    empty.textContent = '연결이 완료되면 전략 리포트와 템플릿이 자동으로 표시됩니다.';
-    list.appendChild(empty);
+function handlePostSubmit(event) {
+  event.preventDefault();
+  const title = elements.postTitle.value.trim();
+  const content = elements.postContent.value.trim();
+  const category = elements.postCategory.value;
+  const tags = elements.postTags.value
+    .split(',')
+    .map(tag => tag.trim())
+    .filter(Boolean);
+
+  if (!title || !content) {
+    alert('제목과 내용을 모두 입력해주세요.');
     return;
   }
 
-  resources.forEach(item => {
-    const row = document.createElement('div');
-    row.className = 'resource-item';
-    row.innerHTML = `
-      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" aria-hidden="true">
-        <path d="M5 8.5a1.5 1.5 0 0 1 1.5-1.5h11A1.5 1.5 0 0 1 19 8.5v7a1.5 1.5 0 0 1-1.5 1.5h-11A1.5 1.5 0 0 1 5 15.5v-7Z" />
-        <path d="M9 6.5V5a1 1 0 0 1 1-1h4a1 1 0 0 1 1 1v1.5" />
-      </svg>
-      <div>
-        <a href="${item.href}" target="_blank" rel="noopener" aria-label="${item.title}">${item.title}</a>
-        <div style="font-size:0.76rem;color:rgba(200,224,255,0.55);margin-top:4px;">${item.meta || ''}</div>
-      </div>
-    `;
-    list.appendChild(row);
+  const excerpt = content.replace(/<[^>]*>/g, '').replace(/\s+/g, ' ').trim().slice(0, 150);
+  const newPost = {
+    id: `new-${Date.now()}`,
+    category,
+    hero: '🆕',
+    title,
+    excerpt: `${excerpt}${excerpt.length === 150 ? '…' : ''}`,
+    content: `<p>${content.replace(/\n{2,}/g, '</p><p>').replace(/\n/g, '<br>')}</p>`,
+    author: 'You',
+    created: '방금 전',
+    stats: { likes: 0, comments: 0, views: 1 },
+    tags: tags.length ? tags : ['새글']
+  };
+
+  state.posts.unshift(newPost);
+  elements.postForm.reset();
+  togglePostForm(false);
+  if (category !== state.currentCategory) {
+    selectCategory(category);
+  } else {
+    renderPosts();
+  }
+  elements.boardUpdated.textContent = formatUpdatedAt(new Date().toISOString());
+}
+
+function openDescriptionEditor() {
+  elements.descriptionTextarea.value = state.descriptions[state.currentCategory] ?? '';
+  elements.descriptionEdit.removeAttribute('hidden');
+  elements.descriptionContent.style.display = 'none';
+  elements.descriptionTextarea.focus();
+}
+
+function closeDescriptionEditor() {
+  elements.descriptionEdit.setAttribute('hidden', '');
+  elements.descriptionContent.style.display = '';
+}
+
+function saveDescription() {
+  const value = elements.descriptionTextarea.value.trim();
+  if (value) {
+    state.descriptions[state.currentCategory] = value;
+    elements.descriptionContent.innerHTML = `<p>${value}</p>`;
+  }
+  closeDescriptionEditor();
+}
+
+function initializeEvents() {
+  elements.newPostButton?.addEventListener('click', () => togglePostForm());
+  elements.cancelPostButton?.addEventListener('click', () => {
+    elements.postForm.reset();
+    togglePostForm(false);
   });
+  elements.postForm?.addEventListener('submit', handlePostSubmit);
+  elements.editDescriptionButton?.addEventListener('click', openDescriptionEditor);
+  elements.cancelDescriptionButton?.addEventListener('click', closeDescriptionEditor);
+  elements.saveDescriptionButton?.addEventListener('click', saveDescription);
+  elements.backToBoardButton?.addEventListener('click', closePostDetail);
 }
 
-function setupFilters() {
-  const buttons = document.querySelectorAll('.board-filters button');
-  const indicatorCards = () => Array.from(document.querySelectorAll('#indicatorGrid .method-card'));
-  const comboCards = () => Array.from(document.querySelectorAll('#combinationGrid .method-card'));
-
-  function handleFilter(filter) {
-    buttons.forEach(btn => btn.classList.toggle('active', btn.dataset.filter === filter));
-
-    indicatorCards().forEach(card => {
-      const isVisible = filter === 'all' || card.dataset.group === filter;
-      card.style.display = isVisible ? '' : 'none';
-    });
-
-    comboCards().forEach(card => {
-      const groups = (card.dataset.groups || '').split(',').filter(Boolean);
-      const isVisible = filter === 'all' || groups.includes(filter);
-      card.style.display = isVisible ? '' : 'none';
-    });
-  }
-
-  buttons.forEach(button => {
-    button.addEventListener('click', () => handleFilter(button.dataset.filter));
-  });
-
-  const initial = document.querySelector('.board-filters button.active');
-  handleFilter(initial ? initial.dataset.filter : 'all');
+function init() {
+  renderCategories();
+  populateCategorySelect();
+  elements.boardUpdated.textContent = formatUpdatedAt(forumData.updatedAt);
+  initializeEvents();
+  selectCategory(state.currentCategory);
 }
 
-async function fetchJSON(url) {
-  const response = await fetch(url);
-  if (!response.ok) throw new Error(`Request failed: ${response.status}`);
-  return response.json();
-}
-
-async function loadBoard() {
-  let boardData = clone(fallbackBoard);
-
-  try {
-    const remote = await fetchJSON(`${API_BASE}/board`);
-    boardData = {
-      ...boardData,
-      ...remote,
-      indicators: remote?.indicators?.length ? remote.indicators : boardData.indicators,
-      combinations: remote?.combinations?.length ? remote.combinations : boardData.combinations,
-      resources: remote?.resources ?? boardData.resources,
-      integrations: { ...boardData.integrations, ...remote?.integrations }
-    };
-  } catch (error) {
-    console.info('[METHOD] Using fallback board data.', error);
-  }
-
-  applyBoardData(boardData);
-  setupFilters();
-  updateIntegrationStatus('db', boardData.integrations?.db);
-  updateIntegrationStatus('s3', boardData.integrations?.s3);
-  renderResources(boardData.resources);
-
-  await Promise.allSettled([
-    refreshIntegration('db'),
-    refreshIntegration('s3'),
-    refreshResources()
-  ]);
-}
-
-async function refreshIntegration(key) {
-  try {
-    const payload = await fetchJSON(`${API_BASE}/status/${key}`);
-    updateIntegrationStatus(key, payload);
-  } catch (error) {
-    console.info(`[METHOD] ${key} status fallback.`, error);
-  }
-}
-
-async function refreshResources() {
-  try {
-    const payload = await fetchJSON(`${API_BASE}/resources`);
-    if (Array.isArray(payload) && payload.length) {
-      renderResources(payload);
-    }
-  } catch (error) {
-    console.info('[METHOD] Resource list fallback.', error);
-  }
-}
-
-document.addEventListener('DOMContentLoaded', () => {
-  loadBoard().catch(error => {
-    console.error('[METHOD] 초기화 실패', error);
-  });
-});
+init();


### PR DESCRIPTION
## Summary
- Rebuild the METHOD page into a forum-style board with sidebar category navigation, hero area, editable descriptions, and responsive styling to match the Two.4 aesthetic
- Populate the forum with curated indicator categories, sample posts, and updated layout semantics for list, detail, and post form views
- Implement new front-end logic to render categories, filter posts, handle detail transitions, edit category descriptions, and submit ad-hoc posts

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3a93e8268832fb6186645411b684a