### PR TITLE
Make ORBITS category backgrounds themeable

### DIFF
--- a/apps/web/menu/orbits/index.html
+++ b/apps/web/menu/orbits/index.html
@@ -12,6 +12,10 @@
       --surface-glass: rgba(10, 9, 25, 0.78);
       --surface-panel: rgba(14, 16, 40, 0.68);
       --surface-panel-strong: rgba(18, 22, 48, 0.82);
+      --category-nav-bg: rgba(10, 12, 28, 0.55);
+      --category-nav-hover-bg: rgba(15, 20, 40, 0.85);
+      --category-nav-active-bg: linear-gradient(140deg, rgba(40, 20, 70, 0.85), rgba(18, 30, 54, 0.85));
+      --category-hero-visual-bg: rgba(12, 20, 48, 0.75);
       --text-primary: #e8f6ff;
       --text-secondary: rgba(205, 235, 255, 0.78);
       --text-tertiary: rgba(200, 224, 255, 0.58);
@@ -223,7 +227,7 @@
       border: 1px solid rgba(100, 215, 255, 0.18);
       border-radius: 16px;
       padding: 14px 16px;
-      background: rgba(10, 12, 28, 0.55);
+      background: var(--category-nav-bg, rgba(10, 12, 28, 0.55));
       color: var(--text-secondary);
       font-size: 0.9rem;
       font-weight: 500;
@@ -247,13 +251,16 @@
       border-color: rgba(100, 215, 255, 0.45);
       color: var(--text-primary);
       transform: translateX(4px);
-      background: rgba(15, 20, 40, 0.85);
+      background: var(--category-nav-hover-bg, rgba(15, 20, 40, 0.85));
     }
 
     .category-nav button.active {
       border-color: var(--accent-strong);
       color: var(--text-primary);
-      background: linear-gradient(140deg, rgba(40, 20, 70, 0.85), rgba(18, 30, 54, 0.85));
+      background: var(
+        --category-nav-active-bg,
+        linear-gradient(140deg, rgba(40, 20, 70, 0.85), rgba(18, 30, 54, 0.85))
+      );
       box-shadow: 0 12px 28px rgba(30, 10, 58, 0.55);
     }
 
@@ -400,7 +407,7 @@
       width: 84px;
       height: 84px;
       border-radius: 22px;
-      background: rgba(12, 20, 48, 0.75);
+      background: var(--category-hero-visual-bg, rgba(12, 20, 48, 0.75));
       border: 1px solid rgba(100, 215, 255, 0.25);
       display: grid;
       place-items: center;


### PR DESCRIPTION
## Summary
- introduce CSS custom properties for ORBITS category button and hero backgrounds
- default the navigation hover/active fills to their previous colors while allowing overrides such as transparent themes

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d3e402240c832fa9f636d66382aa28