### PR TITLE
Enhance ORBITS composer layout and media support

### DIFF
--- a/apps/web/menu/orbits/index.html
+++ b/apps/web/menu/orbits/index.html
@@ -868,15 +868,20 @@
     }
 
     .post-detail__media {
+      display: grid;
+      gap: 14px;
+    }
+
+    .post-detail__media-item {
       position: relative;
       border-radius: 16px;
       border: 1px solid rgba(100, 215, 255, 0.18);
       overflow: hidden;
       background: rgba(12, 18, 36, 0.8);
-      max-height: 420px;
+      margin: 0;
     }
 
-    .post-detail__media img {
+    .post-detail__media-item img {
       width: 100%;
       height: 100%;
       object-fit: cover;
@@ -891,6 +896,22 @@
       font-size: 0.9rem;
       display: grid;
       gap: 14px;
+    }
+
+    .post-detail__body .content-size-large {
+      font-size: 1.04rem;
+      color: var(--text-primary);
+      font-weight: 600;
+    }
+
+    .post-detail__body .content-size-small {
+      font-size: 0.82rem;
+      opacity: 0.92;
+    }
+
+    .post-detail__body strong {
+      color: var(--text-primary);
+      font-weight: 700;
     }
 
     .post-detail__body h3 {

--- a/apps/web/menu/orbits/write.html
+++ b/apps/web/menu/orbits/write.html
@@ -45,7 +45,7 @@
     }
 
     main {
-      max-width: 960px;
+      width: min(100%, calc(100vw - 64px));
       margin: 0 auto;
       padding: 120px 24px 80px;
       display: grid;
@@ -102,6 +102,18 @@
       color: rgba(205, 235, 255, 0.78);
     }
 
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
+
     input[type="text"],
     select,
     textarea {
@@ -141,9 +153,9 @@
 
     .image-preview {
       display: grid;
-      gap: 10px;
-      padding: 12px;
-      border-radius: 14px;
+      gap: 14px;
+      padding: 16px;
+      border-radius: 16px;
       border: 1px dashed rgba(100, 215, 255, 0.25);
       background: rgba(5, 10, 20, 0.6);
     }
@@ -152,11 +164,25 @@
       display: none;
     }
 
-    .image-preview__frame {
+    .image-preview__list {
+      display: grid;
+      gap: 12px;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .image-preview__item {
       position: relative;
       border-radius: 12px;
       overflow: hidden;
       border: 1px solid rgba(100, 215, 255, 0.2);
+      background: rgba(8, 12, 28, 0.6);
+    }
+
+    .image-preview__frame {
+      position: relative;
+      border-radius: 12px;
+      overflow: hidden;
+      border-bottom: 1px solid rgba(100, 215, 255, 0.12);
       max-height: 260px;
     }
 
@@ -167,19 +193,79 @@
       display: block;
     }
 
-    .image-preview__info {
-      font-size: 0.8rem;
-      color: var(--text-secondary);
+    .image-preview__meta {
       display: flex;
       justify-content: space-between;
-      flex-wrap: wrap;
+      align-items: center;
+      padding: 10px 12px;
       gap: 8px;
+      font-size: 0.78rem;
+      color: var(--text-secondary);
+    }
+
+    .image-preview__info {
+      font-size: 0.78rem;
+      color: var(--text-tertiary);
+    }
+
+    .image-preview__remove {
+      border: none;
+      background: rgba(26, 34, 56, 0.9);
+      color: var(--text-primary);
+      border-radius: 8px;
+      padding: 6px 10px;
+      font-size: 0.74rem;
+      letter-spacing: 0.05em;
+      text-transform: uppercase;
+      cursor: pointer;
+      transition: opacity 0.2s ease;
+    }
+
+    .image-preview__remove:hover {
+      opacity: 0.8;
     }
 
     .form-actions {
       display: flex;
       justify-content: flex-end;
       gap: 12px;
+    }
+
+    .format-toolbar {
+      display: flex;
+      gap: 8px;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+
+    .format-toolbar__group {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+    }
+
+    .format-toolbar button,
+    .format-toolbar select {
+      border: 1px solid rgba(100, 215, 255, 0.22);
+      background: rgba(8, 12, 28, 0.75);
+      color: var(--text-primary);
+      border-radius: 10px;
+      padding: 8px 12px;
+      font-size: 0.78rem;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+    }
+
+    .format-toolbar button:hover,
+    .format-toolbar select:hover {
+      transform: translateY(-1px);
+      border-color: rgba(100, 215, 255, 0.45);
+    }
+
+    .format-toolbar select {
+      appearance: none;
+      padding-right: 28px;
     }
 
     .btn {
@@ -229,6 +315,9 @@
       .btn {
         width: 100%;
       }
+      .image-preview__frame {
+        max-height: 220px;
+      }
     }
   </style>
 </head>
@@ -260,20 +349,34 @@
 
       <div class="form-field">
         <label for="composeContent">내용</label>
+        <div class="format-toolbar" aria-label="텍스트 서식 도구">
+          <div class="format-toolbar__group">
+            <button type="button" id="formatBold">굵게</button>
+          </div>
+          <div class="format-toolbar__group">
+            <label for="formatSize" class="visually-hidden">글자 크기</label>
+            <select id="formatSize">
+              <option value="" selected>크기 선택</option>
+              <option value="large">크게</option>
+              <option value="small">작게</option>
+              <option value="reset">기본으로</option>
+            </select>
+          </div>
+        </div>
         <textarea id="composeContent" placeholder="전략 개요, 설정 값, 체크 포인트 등을 작성해주세요." required></textarea>
         <p class="field-hint">줄 바꿈은 엔터 두 번을 사용하면 단락으로 변환됩니다.</p>
       </div>
 
       <div class="form-field image-uploader">
         <label for="composeImage">이미지 업로드 (선택)</label>
-        <input type="file" id="composeImage" accept="image/*">
-        <p class="field-hint">최대 500KB 이미지를 권장합니다. JPG, PNG, WEBP를 지원합니다.</p>
+        <input type="file" id="composeImage" accept="image/*" multiple>
+        <p class="field-hint">최대 500KB 이미지를 권장합니다. JPG, PNG, WEBP를 지원하며, 최대 10개까지 한 번에 선택할 수 있습니다.</p>
         <div class="image-preview" id="imagePreview" hidden>
-          <div class="image-preview__frame">
-            <img id="imagePreviewImg" alt="업로드한 이미지 미리보기">
+          <div class="image-preview__list" id="imagePreviewList"></div>
+          <div class="image-preview__meta">
+            <span class="image-preview__info" id="imageInfo"></span>
+            <button type="button" class="image-preview__remove" id="clearImage">모두 제거</button>
           </div>
-          <div class="image-preview__info" id="imageInfo"></div>
-          <button type="button" class="btn btn-secondary" id="clearImage">이미지 제거</button>
         </div>
       </div>
 

--- a/apps/web/menu/orbits/write.js
+++ b/apps/web/menu/orbits/write.js
@@ -8,20 +8,23 @@ const elements = {
   content: document.getElementById('composeContent'),
   imageInput: document.getElementById('composeImage'),
   imagePreview: document.getElementById('imagePreview'),
-  imagePreviewImg: document.getElementById('imagePreviewImg'),
+  imagePreviewList: document.getElementById('imagePreviewList'),
   imageInfo: document.getElementById('imageInfo'),
   clearImage: document.getElementById('clearImage'),
   submit: document.getElementById('composeSubmit'),
   cancel: document.getElementById('composeCancel'),
-  categoryHint: document.getElementById('categoryHint')
+  categoryHint: document.getElementById('categoryHint'),
+  formatBold: document.getElementById('formatBold'),
+  formatSize: document.getElementById('formatSize')
 };
 
 const state = {
-  imageDataUrl: '',
+  images: [],
   submitting: false
 };
 
 const MAX_FILE_BYTES = 550 * 1024;
+const MAX_IMAGES = 10;
 
 function hasLocalStorage() {
   try {
@@ -85,74 +88,205 @@ function updateCategoryHint() {
 }
 
 function clearImagePreview() {
-  state.imageDataUrl = '';
+  state.images = [];
   if (elements.imageInput) {
     elements.imageInput.value = '';
   }
-  if (elements.imagePreview) {
-    elements.imagePreview.hidden = true;
-  }
-  if (elements.imagePreviewImg) {
-    elements.imagePreviewImg.removeAttribute('src');
+  if (elements.imagePreviewList) {
+    elements.imagePreviewList.innerHTML = '';
   }
   if (elements.imageInfo) {
     elements.imageInfo.textContent = '';
   }
+  if (elements.imagePreview) {
+    elements.imagePreview.hidden = true;
+  }
 }
 
-function renderImagePreview(dataUrl, file) {
-  if (!elements.imagePreview || !elements.imagePreviewImg || !elements.imageInfo) return;
-  elements.imagePreviewImg.src = dataUrl;
-  const sizeKb = file ? Math.round(file.size / 1024) : Math.round(dataUrl.length / 1024);
-  const infoParts = [];
-  if (file?.name) infoParts.push(file.name);
-  infoParts.push(`${sizeKb} KB`);
-  elements.imageInfo.textContent = infoParts.join(' · ');
+function renderImagePreview() {
+  if (!elements.imagePreview || !elements.imagePreviewList || !elements.imageInfo) return;
+  elements.imagePreviewList.innerHTML = '';
+  if (!state.images.length) {
+    elements.imagePreview.hidden = true;
+    elements.imageInfo.textContent = '';
+    return;
+  }
+
+  const totalSize = state.images.reduce((sum, image) => sum + image.size, 0);
+  state.images.forEach((image, index) => {
+    const item = document.createElement('div');
+    item.className = 'image-preview__item';
+
+    const frame = document.createElement('div');
+    frame.className = 'image-preview__frame';
+    const img = document.createElement('img');
+    img.src = image.dataUrl;
+    img.alt = image.name ? `${image.name} 미리보기` : '업로드한 이미지 미리보기';
+    frame.appendChild(img);
+    item.appendChild(frame);
+
+    const meta = document.createElement('div');
+    meta.className = 'image-preview__meta';
+    const info = document.createElement('span');
+    info.className = 'image-preview__info';
+    info.textContent = image.name ? `${image.name} · ${Math.round(image.size / 1024)} KB` : `${Math.round(image.size / 1024)} KB`;
+    meta.appendChild(info);
+
+    const removeButton = document.createElement('button');
+    removeButton.type = 'button';
+    removeButton.className = 'image-preview__remove';
+    removeButton.textContent = '제거';
+    removeButton.setAttribute('aria-label', `${image.name || '이미지'} 제거`);
+    removeButton.addEventListener('click', () => {
+      state.images.splice(index, 1);
+      renderImagePreview();
+    });
+    meta.appendChild(removeButton);
+    item.appendChild(meta);
+
+    elements.imagePreviewList.appendChild(item);
+  });
+
+  const summarySize = Math.round(totalSize / 1024);
+  elements.imageInfo.textContent = `${state.images.length}개 이미지 · ${summarySize} KB`;
   elements.imagePreview.hidden = false;
 }
 
-function handleImageChange() {
+async function handleImageChange() {
   if (!elements.imageInput || !elements.imageInput.files?.length) {
-    clearImagePreview();
+    if (elements.imageInput) {
+      elements.imageInput.value = '';
+    }
+    if (!state.images.length) {
+      clearImagePreview();
+    }
     return;
   }
-  const file = elements.imageInput.files[0];
-  if (!file.type.startsWith('image/')) {
-    alert('이미지 파일만 업로드할 수 있습니다.');
-    clearImagePreview();
+
+  const files = Array.from(elements.imageInput.files);
+  const errors = [];
+
+  for (const file of files) {
+    if (!file.type.startsWith('image/')) {
+      errors.push(`${file.name} — 이미지 파일만 업로드할 수 있습니다.`);
+      continue;
+    }
+    if (file.size > MAX_FILE_BYTES) {
+      errors.push(`${file.name} — 이미지 크기가 너무 큽니다. 500KB 이하의 이미지를 사용해주세요.`);
+      continue;
+    }
+    if (state.images.length >= MAX_IMAGES) {
+      errors.push(`${file.name} — 이미지는 최대 ${MAX_IMAGES}개까지 첨부할 수 있습니다.`);
+      continue;
+    }
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      if (dataUrl.length > MAX_IMAGE_DATA_URL_LENGTH) {
+        errors.push(`${file.name} — 이미지 데이터가 너무 큽니다. 해상도를 낮춰 다시 시도해주세요.`);
+        continue;
+      }
+      state.images.push({
+        dataUrl,
+        name: file.name,
+        size: file.size
+      });
+    } catch (error) {
+      errors.push(`${file.name} — 이미지를 읽는 중 오류가 발생했습니다.`);
+    }
+  }
+
+  elements.imageInput.value = '';
+  renderImagePreview();
+
+  if (errors.length) {
+    alert(errors.join('\n'));
+  }
+}
+
+function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = reader.result;
+      if (typeof result !== 'string') {
+        reject(new Error('INVALID_RESULT'));
+        return;
+      }
+      if (!result.startsWith('data:image/')) {
+        reject(new Error('INVALID_TYPE'));
+        return;
+      }
+      resolve(result);
+    };
+    reader.onerror = () => reject(new Error('READ_ERROR'));
+    reader.readAsDataURL(file);
+  });
+}
+
+function toggleBold() {
+  if (!elements.content) return;
+  const textarea = elements.content;
+  const { selectionStart, selectionEnd, value } = textarea;
+  if (selectionStart === undefined || selectionEnd === undefined) return;
+  const selected = value.slice(selectionStart, selectionEnd);
+  if (!selected) {
+    alert('굵게 만들 텍스트를 선택해주세요.');
+    textarea.focus();
     return;
   }
-  if (file.size > MAX_FILE_BYTES) {
-    alert('이미지 크기가 너무 큽니다. 500KB 이하의 이미지를 사용해주세요.');
-    clearImagePreview();
+  const isWrapped = /^\s*\[b\][\s\S]*\[\/b\]\s*$/.test(selected);
+  let replacement;
+  if (isWrapped) {
+    replacement = selected.replace(/\[b\]([\s\S]*?)\[\/b\]/g, '$1');
+  } else {
+    const cleanSelected = selected.replace(/\[\/?b\]/g, '');
+    replacement = `[b]${cleanSelected}[/b]`;
+    const newValue = `${value.slice(0, selectionStart)}${replacement}${value.slice(selectionEnd)}`;
+    textarea.value = newValue;
+    const innerStart = selectionStart + 3;
+    const innerEnd = innerStart + cleanSelected.length;
+    textarea.focus();
+    textarea.setSelectionRange(innerStart, innerEnd);
     return;
   }
-  const reader = new FileReader();
-  reader.onload = () => {
-    const result = reader.result;
-    if (typeof result !== 'string') {
-      alert('이미지를 불러오지 못했습니다. 다른 파일을 선택해주세요.');
-      clearImagePreview();
-      return;
-    }
-    if (!result.startsWith('data:image/')) {
-      alert('지원하지 않는 이미지 형식입니다.');
-      clearImagePreview();
-      return;
-    }
-    if (result.length > MAX_IMAGE_DATA_URL_LENGTH) {
-      alert('이미지 데이터가 너무 큽니다. 해상도를 낮춰 다시 시도해주세요.');
-      clearImagePreview();
-      return;
-    }
-    state.imageDataUrl = result;
-    renderImagePreview(result, file);
-  };
-  reader.onerror = () => {
-    alert('이미지를 읽는 중 오류가 발생했습니다. 다시 시도해주세요.');
-    clearImagePreview();
-  };
-  reader.readAsDataURL(file);
+  const newValue = `${value.slice(0, selectionStart)}${replacement}${value.slice(selectionEnd)}`;
+  textarea.value = newValue;
+  const start = selectionStart;
+  const end = start + replacement.length;
+  textarea.focus();
+  textarea.setSelectionRange(start, end);
+}
+
+function applyFontSize(size) {
+  if (!elements.content) return;
+  const textarea = elements.content;
+  const { selectionStart, selectionEnd, value } = textarea;
+  if (selectionStart === undefined || selectionEnd === undefined) return;
+  const selected = value.slice(selectionStart, selectionEnd);
+  if (!selected) {
+    alert('크기를 변경할 텍스트를 선택해주세요.');
+    textarea.focus();
+    return;
+  }
+
+  const cleaned = selected.replace(/\[size=(?:small|large|normal)\]/g, '').replace(/\[\/size\]/g, '');
+  let replacement = cleaned;
+
+  if (size === 'large' || size === 'small') {
+    replacement = `[size=${size}]${cleaned}[/size]`;
+  }
+
+  const newValue = `${value.slice(0, selectionStart)}${replacement}${value.slice(selectionEnd)}`;
+  textarea.value = newValue;
+  let start = selectionStart;
+  let end = start + replacement.length;
+  if (size === 'large' || size === 'small') {
+    const offset = `[size=${size}]`.length;
+    start += offset;
+    end = start + cleaned.length;
+  }
+  textarea.focus();
+  textarea.setSelectionRange(start, end);
 }
 
 async function postOrbitEntry(payload) {
@@ -203,6 +337,8 @@ async function handleSubmit(event) {
     return;
   }
 
+  const images = state.images.map(image => image.dataUrl).filter(Boolean);
+
   const payload = {
     title,
     category,
@@ -210,8 +346,9 @@ async function handleSubmit(event) {
     tags: tags.length ? tags : ['새글'],
     author: 'You'
   };
-  if (state.imageDataUrl) {
-    payload.image = state.imageDataUrl;
+  if (images.length) {
+    payload.images = images;
+    payload.image = images[0];
   }
 
   try {
@@ -245,6 +382,16 @@ function init() {
   elements.clearImage?.addEventListener('click', event => {
     event.preventDefault();
     clearImagePreview();
+  });
+  elements.formatBold?.addEventListener('click', event => {
+    event.preventDefault();
+    toggleBold();
+  });
+  elements.formatSize?.addEventListener('change', event => {
+    const value = event.target?.value;
+    if (!value) return;
+    applyFontSize(value === 'reset' ? 'reset' : value);
+    event.target.value = '';
   });
   elements.cancel?.addEventListener('click', event => {
     event.preventDefault();


### PR DESCRIPTION
## Summary
- widen the ORBITS compose layout and add lightweight toolbar controls for bold text and size tweaks
- allow attaching and managing up to 10 images per post with multi-preview UI and backend support for image arrays
- render attached image galleries and formatted content on the ORBITS detail view with refreshed styling

## Testing
- npm run start

------
https://chatgpt.com/codex/tasks/task_e_68d41bf3e4b4832f93b30c3ab6708222