### PR TITLE
Ensure dominance sparkline renders reliably

### DIFF
--- a/apps/web/menu/cosmos/cosmos.js
+++ b/apps/web/menu/cosmos/cosmos.js
@@ -29,6 +29,258 @@ const fmtPpFull = n => {
   return `${v >= 0 ? '+' : ''}${v.toFixed(2)}pp`;
 };
 
+const DOMINANCE_COLORS = ['#00ffff', '#ff66cc', '#ffd166'];
+const activeDomSpark = { container: null, coins: null, observer: null, raf: 0, timeout: 0 };
+
+function resetDominanceSparkTracking() {
+  if (activeDomSpark.observer && activeDomSpark.container) {
+    try { activeDomSpark.observer.unobserve(activeDomSpark.container); }
+    catch { /* ignore */ }
+  }
+  if (activeDomSpark.observer) {
+    try { activeDomSpark.observer.disconnect(); }
+    catch { /* ignore */ }
+  }
+  activeDomSpark.observer = null;
+  if (activeDomSpark.raf) {
+    cancelAnimationFrame(activeDomSpark.raf);
+    activeDomSpark.raf = 0;
+  }
+  if (activeDomSpark.timeout) {
+    clearTimeout(activeDomSpark.timeout);
+    activeDomSpark.timeout = 0;
+  }
+  activeDomSpark.container = null;
+  activeDomSpark.coins = null;
+}
+
+function toNumeric(value, { allowDate = false } = {}) {
+  if (value == null) return NaN;
+  if (typeof value === 'string') {
+    const trimmed = value.trim();
+    if (!trimmed) return NaN;
+    value = trimmed;
+  }
+  const num = Number(value);
+  if (Number.isFinite(num)) return num;
+  if (allowDate) {
+    const date = new Date(value);
+    const time = date.getTime();
+    if (Number.isFinite(time)) return time;
+  }
+  return NaN;
+}
+
+function normaliseDominanceSeries(series) {
+  if (!Array.isArray(series)) return [];
+  const out = [];
+  for (const point of series) {
+    let rawTime;
+    let rawValue;
+    if (Array.isArray(point)) {
+      rawTime = point[0];
+      rawValue = point[1];
+    } else if (point && typeof point === 'object') {
+      rawTime = point.time ?? point.timestamp ?? point.t ?? point.time_ms ?? point[0];
+      rawValue = point.value ?? point.v ?? point.dominance ?? point[1];
+    } else {
+      continue;
+    }
+    const time = toNumeric(rawTime, { allowDate: true });
+    const value = toNumeric(rawValue);
+    if (!Number.isFinite(time) || !Number.isFinite(value)) continue;
+    out.push({ time, value });
+  }
+  return out.sort((a, b) => a.time - b.time);
+}
+
+function prepareDominanceCoins(rawCoins) {
+  if (!Array.isArray(rawCoins)) return [];
+  const prepared = [];
+  for (const coin of rawCoins) {
+    const series = normaliseDominanceSeries(coin?.series);
+    if (!series.length) continue;
+    const first = series[0].value;
+    const last = series[series.length - 1].value;
+    const dominanceValue = toNumeric(coin?.dominance);
+    const changeValue = toNumeric(coin?.change);
+    const dominance = Number.isFinite(dominanceValue) ? dominanceValue : last;
+    let change = Number.isFinite(changeValue) ? changeValue : NaN;
+    if (!Number.isFinite(change) && Number.isFinite(first) && Number.isFinite(last)) {
+      change = last - first;
+    }
+    prepared.push({
+      id: coin?.id || '',
+      name: coin?.name || (coin?.id || '').toUpperCase(),
+      symbol: (coin?.symbol || '').toUpperCase(),
+      dominance,
+      change,
+      series
+    });
+  }
+  return prepared
+    .sort((a, b) => {
+      const aDom = Number.isFinite(a.dominance) ? a.dominance : -Infinity;
+      const bDom = Number.isFinite(b.dominance) ? b.dominance : -Infinity;
+      return bDom - aDom;
+    })
+    .slice(0, 3);
+}
+
+function drawDominanceSparkline(container, coins) {
+  if (!container || !Array.isArray(coins) || !coins.length) {
+    resetDominanceSparkTracking();
+    return;
+  }
+  let canvas = container.querySelector('canvas');
+  if (!canvas) {
+    canvas = document.createElement('canvas');
+    container.appendChild(canvas);
+  }
+  const width = Math.max(container.clientWidth || 0, 220);
+  const height = 120;
+  const dpr = window.devicePixelRatio || 1;
+  canvas.style.width = `${width}px`;
+  canvas.style.height = `${height}px`;
+  canvas.width = Math.round(width * dpr);
+  canvas.height = Math.round(height * dpr);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, width, height);
+  ctx.fillStyle = 'rgba(5, 10, 24, 0.75)';
+  ctx.fillRect(0, 0, width, height);
+
+  const times = [];
+  const values = [];
+  coins.forEach(coin => {
+    if (!Array.isArray(coin.series)) return;
+    coin.series.forEach(point => {
+      times.push(point.time);
+      values.push(point.value);
+    });
+  });
+  if (!times.length || !values.length) return;
+
+  const minTime = Math.min(...times);
+  const maxTime = Math.max(...times);
+  const minVal = Math.min(...values);
+  const maxVal = Math.max(...values);
+  const timeSpan = maxTime - minTime || 1;
+  const valueRange = maxVal - minVal;
+  const pad = valueRange === 0 ? Math.max(1, Math.abs(maxVal) * 0.05 || 1) : valueRange * 0.1;
+  const vMin = minVal - pad;
+  const vMax = maxVal + pad;
+  const valueSpan = vMax - vMin || 1;
+
+  const leftPad = 12;
+  const rightPad = 12;
+  const topPad = 12;
+  const bottomPad = 12;
+  const innerWidth = width - leftPad - rightPad;
+  const innerHeight = height - topPad - bottomPad;
+  if (innerWidth <= 0 || innerHeight <= 0) return;
+
+  ctx.save();
+  ctx.strokeStyle = 'rgba(0, 255, 255, 0.12)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  for (let i = 0; i <= 4; i++) {
+    const y = topPad + (innerHeight / 4) * i;
+    ctx.moveTo(leftPad, y);
+    ctx.lineTo(leftPad + innerWidth, y);
+  }
+  ctx.stroke();
+  ctx.restore();
+
+  coins.forEach((coin, idx) => {
+    const series = coin.series;
+    if (!Array.isArray(series) || series.length < 2) return;
+    const color = DOMINANCE_COLORS[idx % DOMINANCE_COLORS.length];
+    ctx.save();
+    ctx.lineWidth = 2;
+    ctx.lineJoin = 'round';
+    ctx.lineCap = 'round';
+    ctx.strokeStyle = color;
+    ctx.shadowColor = color;
+    ctx.shadowBlur = 12;
+    ctx.beginPath();
+    series.forEach((point, i) => {
+      const x = leftPad + ((point.time - minTime) / timeSpan) * innerWidth;
+      const y = topPad + (1 - ((point.value - vMin) / valueSpan)) * innerHeight;
+      if (i === 0) ctx.moveTo(x, y);
+      else ctx.lineTo(x, y);
+    });
+    ctx.stroke();
+    ctx.shadowBlur = 0;
+    const last = series[series.length - 1];
+    if (last) {
+      const x = leftPad + ((last.time - minTime) / timeSpan) * innerWidth;
+      const y = topPad + (1 - ((last.value - vMin) / valueSpan)) * innerHeight;
+      ctx.fillStyle = color;
+      ctx.beginPath();
+      ctx.arc(x, y, 3, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    ctx.restore();
+  });
+
+  ctx.save();
+  const grad = ctx.createLinearGradient(0, topPad, 0, topPad + innerHeight);
+  grad.addColorStop(0, 'rgba(0, 0, 0, 0)');
+  grad.addColorStop(1, 'rgba(0, 0, 0, 0.35)');
+  ctx.fillStyle = grad;
+  ctx.fillRect(leftPad, topPad, innerWidth, innerHeight);
+  ctx.restore();
+}
+
+function activateDominanceSparkline(container, coins) {
+  if (!container || !Array.isArray(coins) || !coins.length) {
+    resetDominanceSparkTracking();
+    return;
+  }
+
+  resetDominanceSparkTracking();
+  activeDomSpark.container = container;
+  activeDomSpark.coins = coins;
+
+  const render = () => drawDominanceSparkline(container, coins);
+  render();
+
+  activeDomSpark.raf = requestAnimationFrame(() => {
+    activeDomSpark.raf = 0;
+    render();
+    activeDomSpark.timeout = setTimeout(() => {
+      activeDomSpark.timeout = 0;
+      render();
+    }, 240);
+  });
+
+  if (typeof ResizeObserver === 'function') {
+    const observer = new ResizeObserver(entries => {
+      for (const entry of entries) {
+        if (entry.target !== container) continue;
+        if (activeDomSpark.raf) cancelAnimationFrame(activeDomSpark.raf);
+        activeDomSpark.raf = requestAnimationFrame(() => {
+          activeDomSpark.raf = 0;
+          drawDominanceSparkline(container, coins);
+        });
+      }
+    });
+    observer.observe(container);
+    activeDomSpark.observer = observer;
+  }
+}
+
+window.addEventListener('resize', () => {
+  const { container, coins } = activeDomSpark;
+  if (!container || !coins || !document.body.contains(container)) {
+    resetDominanceSparkTracking();
+    return;
+  }
+  drawDominanceSparkline(container, coins);
+});
+
 const escapeHtml = str => String(str ?? '')
   .replace(/&/g, '&amp;')
   .replace(/</g, '&lt;')
@@ -549,6 +801,10 @@ function buildHub(sections){
       hubBody.innerHTML=s.html;
       hubBig.style.fontSize = s.smallCenter ? '16px' : '';
       hubBig.style.whiteSpace = s.smallCenter ? 'nowrap' : '';
+      resetDominanceSparkTracking();
+      if (typeof s.onActivate === 'function') {
+        requestAnimationFrame(() => s.onActivate(hubBody));
+      }
     };
     
     path.addEventListener("click", act); 
@@ -582,20 +838,41 @@ async function initHub(){
   const hasFlow = Number.isFinite(r1h) && Number.isFinite(r24);
 
   const dominanceMulti = await safeJson('/api/dominance/top3?days=30');
-  let domDelta30d = null;
-  let domDetailAvailable = false;
-  if (dominanceMulti && Array.isArray(dominanceMulti.coins)) {
-    const btcDom = dominanceMulti.coins.find(c => {
-      const id = (c?.id || '').toLowerCase();
-      const sym = (c?.symbol || '').toLowerCase();
-      return id === 'bitcoin' || sym === 'btc';
-    });
-    if (btcDom?.series?.length) {
-      domDetailAvailable = true;
-      const first = Number(btcDom.series[0]?.value);
-      const last = Number(btcDom.series[btcDom.series.length - 1]?.value);
-      if (Number.isFinite(first) && Number.isFinite(last)) domDelta30d = last - first;
-    }
+  const dominanceCoins = prepareDominanceCoins(dominanceMulti?.coins);
+  const btcDomCoin = dominanceCoins.find(c => {
+    const id = (c?.id || '').toLowerCase();
+    const sym = (c?.symbol || '').toUpperCase();
+    return id === 'bitcoin' || sym === 'BTC';
+  }) || null;
+  const domDetailAvailable = dominanceCoins.length > 0;
+  const domDelta30d = Number.isFinite(btcDomCoin?.change) ? btcDomCoin.change : null;
+
+  let domDetailHtml = '<div class="dom-empty">Dominance data unavailable</div>';
+  let domOnActivate;
+  if (domDetailAvailable) {
+    const rowsHtml = dominanceCoins.map((coin, idx) => {
+      const color = DOMINANCE_COLORS[idx % DOMINANCE_COLORS.length];
+      const symbol = (coin.symbol || '').toUpperCase();
+      const displayName = coin.name || symbol || '—';
+      const showSymbol = Boolean(symbol) && symbol !== String(displayName).toUpperCase();
+      const symbolHtml = showSymbol ? ` <span class="dom-symbol">${escapeHtml(symbol)}</span>` : '';
+      const nameLabel = escapeHtml(displayName);
+      const domText = Number.isFinite(coin.dominance) ? `${coin.dominance.toFixed(2)}%` : '—';
+      const delta = Number(coin.change);
+      const deltaClass = Number.isFinite(delta) ? (delta > 0 ? 'up' : delta < 0 ? 'down' : 'neutral') : 'neutral';
+      const deltaText = Number.isFinite(delta) ? `${delta >= 0 ? '+' : ''}${delta.toFixed(2)}pp` : '—';
+      return `<div class="dom-row" style="--dom-color:${color}"><span class="dom-dot" aria-hidden="true"></span><span class="dom-name">${nameLabel}${symbolHtml}</span><span class="dom-value">${domText}</span><span class="dom-delta ${deltaClass}">${deltaText}</span></div>`;
+    }).join('');
+    const domDetailLink = `<a class="dom-link" href="/menu/cosmos/dominance.html">Dominance detail<span aria-hidden="true">→</span></a>`;
+    domDetailHtml = `<div class="dom-detail"><div class="dom-rows">${rowsHtml}</div><div class="dom-chart" data-dom-spark><canvas></canvas></div>${domDetailLink}</div>`;
+    domOnActivate = panel => {
+      const target = panel.querySelector('[data-dom-spark]');
+      if (!target) {
+        resetDominanceSparkTracking();
+        return;
+      }
+      activateDominanceSparkline(target, dominanceCoins);
+    };
   }
 
   const listTop=(by,n=10)=> mkts.slice().sort((a,b)=> (b[by]??0)-(a[by]??0)).slice(0,n);
@@ -617,15 +894,18 @@ async function initHub(){
   
   const byId=Object.fromEntries(mkts.map(m=>[m.id,m]));
   const btc=byId.bitcoin||null;
-  const dom = global?.data?.market_cap_percentage?.btc ?? null;
-  const domCenterSub = dom!=null ? `30D Δ ${fmtPpFull(domDelta30d)}` : 'DOMINANCE';
-  const domDeltaClass = Number.isFinite(domDelta30d) ? (domDelta30d >= 0 ? 'up' : 'down') : null;
-  const domDeltaHtml = domDeltaClass
-    ? `<span class="pct ${domDeltaClass}" style="font-size:1rem">${(domDelta30d>=0?'+':'')}${domDelta30d.toFixed(2)}pp</span>`
-    : `<span style="opacity:.5">—</span>`;
-  const domDetailLink = domDetailAvailable
-    ? `<a href="/menu/cosmos/dominance.html" style="display:inline-flex;align-items:center;gap:6px;margin-top:16px;padding:8px 14px;border-radius:12px;border:1px solid rgba(0,255,255,0.35);background:rgba(0,255,255,0.06);color:#00ffff;text-decoration:none;font-family:'Orbitron',monospace;font-size:0.72rem;letter-spacing:1.6px;text-transform:uppercase;">Dominance detail<span aria-hidden="true">→</span></a>`
-    : `<div style="margin-top:16px;font-size:0.72rem;color:rgba(255,255,255,0.45);font-family:'Orbitron',monospace;text-transform:uppercase;letter-spacing:1px;">Detail data unavailable</div>`;
+  const rawDom = toNumeric(global?.data?.market_cap_percentage?.btc);
+  const dom = Number.isFinite(rawDom)
+    ? rawDom
+    : (Number.isFinite(btcDomCoin?.dominance) ? btcDomCoin.dominance : null);
+  const domCenterSub = Number.isFinite(domDelta30d) ? `30D Δ ${fmtPpFull(domDelta30d)}` : 'DOMINANCE';
+  let domDeltaHtml = `<span style="opacity:.5">—</span>`;
+  if (Number.isFinite(domDelta30d)) {
+    const text = `${domDelta30d >= 0 ? '+' : ''}${domDelta30d.toFixed(2)}pp`;
+    if (domDelta30d > 0) domDeltaHtml = `<span class="pct up" style="font-size:1rem">${text}</span>`;
+    else if (domDelta30d < 0) domDeltaHtml = `<span class="pct down" style="font-size:1rem">${text}</span>`;
+    else domDeltaHtml = `<span style="color:rgba(255,255,255,0.7);font-size:1rem;font-family:'Orbitron',monospace;letter-spacing:1px;">${text}</span>`;
+  }
   const f = Number(fng?.data?.[0]?.value ?? NaN);
 
   const gLast = globalLS?.long_pct_last;
@@ -691,23 +971,24 @@ async function initHub(){
       html: isFinite(f)?gaugeHTML(f):"<div style='color:#8b95a7'>No data available</div>"
     },
     {
-      badge:"BTC MC", 
-      title:"Bitcoin Market Cap", 
-      centerTop: btc?fmtMoney(btc.market_cap):"—", 
-      centerSub:"BTC MCAP", 
+      badge:"BTC MC",
+      title:"Bitcoin Market Cap",
+      centerTop: btc?fmtMoney(btc.market_cap):"—",
+      centerSub:"BTC MCAP",
       html:`<div style="font-family:'Orbitron',monospace;text-transform:uppercase;letter-spacing:2px;color:#00ffff;text-shadow:0 0 10px currentColor">Bitcoin Market Cap</div>
             <div style="margin-top:12px;font-size:24px;font-weight:700">${btc?fmtMoney(btc.market_cap):'—'}</div>`
     },
       whaleSec,
     {
       badge:"BTC DOM",
-      title:"Bitcoin Dominance",
-      centerTop: dom!=null?dom.toFixed(2)+"%":"—",
+      title:"Market Dominance",
+      centerTop: Number.isFinite(dom)?dom.toFixed(2)+"%":"—",
       centerSub: domCenterSub,
-      html:`<div style="font-family:'Orbitron',monospace;text-transform:uppercase;letter-spacing:2px;color:#00ffff;text-shadow:0 0 10px currentColor">Bitcoin Dominance</div>
-            <div style="margin-top:12px;font-size:24px;font-weight:700">${dom!=null?dom.toFixed(2)+"%":"—"}</div>
+      html:`<div style="font-family:'Orbitron',monospace;text-transform:uppercase;letter-spacing:2px;color:#00ffff;text-shadow:0 0 10px currentColor">Market Dominance</div>
+            <div style="margin-top:12px;font-size:24px;font-weight:700">${Number.isFinite(dom)?dom.toFixed(2)+"%":"—"}</div>
             <div style="margin-top:12px;font-size:0.9rem;color:rgba(255,255,255,0.75);font-family:'Orbitron',monospace;text-transform:uppercase;letter-spacing:1px;display:flex;align-items:center;gap:8px;">30D Change ${domDeltaHtml}</div>
-            ${domDetailLink}`
+            ${domDetailHtml}`,
+      onActivate: domOnActivate
     },
   ];
   

--- a/apps/web/menu/cosmos/index.html
+++ b/apps/web/menu/cosmos/index.html
@@ -83,6 +83,18 @@
     }
     
     a { color: inherit; text-decoration: none; }
+
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
+    }
     
     /* Star Canvas with Glow */
     #whiteStars {
@@ -96,9 +108,12 @@
     
     /* ---- Global Header (Echoes inspired) ---- */
     .nav-header {
-      position: sticky;
+      position: fixed;
       top: 0;
+      left: 0;
+      right: 0;
       z-index: 160;
+      width: 100%;
       background: linear-gradient(135deg, rgba(10, 15, 26, 0.95), rgba(24, 20, 40, 0.9));
       border-bottom: 1px solid rgba(0, 255, 255, 0.18);
       backdrop-filter: blur(26px);
@@ -207,6 +222,7 @@
     .nav-menu {
       list-style: none;
       display: flex;
+      align-items: center;
       gap: 6px;
       padding: 0;
       margin: 0;
@@ -302,26 +318,9 @@
       box-shadow: 0 0 24px rgba(0, 255, 255, 0.18);
     }
 
-    .nav-right {
-      display: flex;
-      align-items: center;
-      gap: 14px;
-      color: rgba(182, 202, 235, 0.75);
-      font-family: 'Orbitron', monospace;
-      font-size: 0.7rem;
-      letter-spacing: 1px;
-      text-transform: uppercase;
-    }
-
-    .nav-right span:last-child {
-      color: rgba(0, 255, 255, 0.85);
-      text-shadow: 0 0 12px rgba(0, 255, 255, 0.55);
-    }
-
     @media (max-width: 960px) {
       .nav-container {
-        flex-direction: column;
-        align-items: stretch;
+        align-items: center;
         gap: 12px;
       }
 
@@ -337,7 +336,10 @@
       }
 
       .nav-menu {
-        width: 100%;
+        position: absolute;
+        top: calc(100% + 12px);
+        left: 20px;
+        right: 20px;
         flex-direction: column;
         gap: 8px;
         padding: 14px;
@@ -345,6 +347,9 @@
         background: linear-gradient(135deg, rgba(5, 10, 20, 0.92), rgba(18, 16, 32, 0.92));
         border: 1px solid rgba(0, 255, 255, 0.22);
         box-shadow: 0 18px 36px rgba(4, 12, 24, 0.45);
+        max-height: min(70vh, 420px);
+        overflow-y: auto;
+        z-index: 10;
       }
 
       .nav-header.js-nav:not(.open) .nav-menu {
@@ -361,160 +366,114 @@
         padding: 12px 14px;
         font-size: 0.85rem;
       }
-
-      .nav-right {
-        width: 100%;
-        justify-content: space-between;
-        font-size: 0.66rem;
-      }
     }
 
     /* Cyberpunk Star Controller */
     .star-ctl {
       display: flex;
       align-items: center;
-      gap: 18px;
-      flex-wrap: wrap;
-      margin: -12px 0 32px auto;
-      padding: 16px 20px;
-      max-width: 100%;
-      background: linear-gradient(135deg, rgba(0, 255, 255, 0.14), rgba(10, 15, 35, 0.82));
+      gap: 10px;
+      margin: 16px 0 32px auto;
+      padding: 6px 12px;
+      border-radius: 999px;
+      background: linear-gradient(135deg, rgba(0, 255, 255, 0.12), rgba(10, 15, 35, 0.7));
       border: 1px solid rgba(0, 255, 255, 0.28);
-      border-radius: 24px;
-      backdrop-filter: blur(20px);
-      box-shadow: 0 12px 26px rgba(6, 12, 24, 0.48);
-      font-family: 'Orbitron', monospace;
-      text-transform: uppercase;
-      transition: box-shadow 0.3s ease, border-color 0.3s ease;
+      backdrop-filter: blur(12px);
+      box-shadow: 0 10px 24px rgba(6, 12, 24, 0.38);
+      transition: border-color 0.3s ease, box-shadow 0.3s ease;
+      width: fit-content;
     }
 
     .star-ctl.focus {
       border-color: rgba(153, 69, 255, 0.55);
-      box-shadow: 0 18px 32px rgba(0, 255, 255, 0.32);
-    }
-
-    .star-ctl-meta {
-      display: flex;
-      align-items: center;
-      gap: 12px;
-      cursor: pointer;
-      min-width: 0;
-    }
-
-    .star-ctl-icon {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      width: 34px;
-      height: 34px;
-      border-radius: 12px;
-      background: linear-gradient(135deg, rgba(0, 255, 255, 0.2), rgba(153, 69, 255, 0.2));
-      border: 1px solid rgba(0, 255, 255, 0.35);
-      color: rgba(0, 255, 255, 0.92);
-      font-size: 1rem;
-      text-shadow: 0 0 12px currentColor;
-      box-shadow: inset 0 0 14px rgba(0, 255, 255, 0.25);
-    }
-
-    .star-ctl-copy {
-      display: flex;
-      flex-direction: column;
-      gap: 2px;
-      min-width: 0;
-    }
-
-    .star-ctl-title {
-      font-size: 0.7rem;
-      letter-spacing: 1.6px;
-      color: rgba(0, 255, 255, 0.78);
-    }
-
-    .star-ctl-value {
-      font-size: 0.85rem;
-      letter-spacing: 1.8px;
-      color: #ffffff;
-      text-shadow: 0 0 12px rgba(0, 255, 255, 0.6);
+      box-shadow: 0 18px 32px rgba(0, 255, 255, 0.28);
     }
 
     .star-ctl-slider {
       position: relative;
-      flex: 1;
-      min-width: min(260px, 100%);
-      display: flex;
-      align-items: center;
-      padding: 6px 0;
+      width: clamp(120px, 22vw, 180px);
+      height: 18px;
     }
 
     .star-ctl-track {
-      position: relative;
-      flex: 1;
-      height: 8px;
+      position: absolute;
+      top: 50%;
+      left: 0;
+      right: 0;
+      height: 4px;
+      transform: translateY(-50%);
       border-radius: 999px;
-      background: rgba(0, 255, 255, 0.12);
+      background: rgba(0, 255, 255, 0.22);
       overflow: hidden;
-      box-shadow: inset 0 0 12px rgba(0, 255, 255, 0.25);
     }
 
     .star-ctl-progress {
       position: absolute;
-      inset: 0;
-      width: 0%;
-      border-radius: 999px;
-      background: linear-gradient(90deg, rgba(0, 255, 255, 0.65), rgba(153, 69, 255, 0.65));
-      box-shadow: 0 0 18px rgba(0, 255, 255, 0.4);
-      transition: width 0.25s ease;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: 0;
+      background: linear-gradient(90deg, rgba(0, 255, 255, 0.8), rgba(153, 69, 255, 0.8));
+      box-shadow: 0 0 12px rgba(0, 255, 255, 0.4);
     }
 
     .star-ctl-slider input[type=range] {
-      position: absolute;
-      inset: -10px 0;
-      width: 100%;
-      height: calc(100% + 20px);
-      background: none;
-      border: none;
-      outline: none;
       -webkit-appearance: none;
       appearance: none;
+      position: absolute;
+      inset: 0;
+      margin: 0;
+      background: transparent;
       cursor: pointer;
     }
 
+    .star-ctl-slider input[type=range]:focus-visible {
+      outline: none;
+    }
+
     .star-ctl-slider input[type=range]::-webkit-slider-runnable-track {
-      height: 8px;
+      height: 4px;
       background: transparent;
     }
 
     .star-ctl-slider input[type=range]::-webkit-slider-thumb {
       -webkit-appearance: none;
-      width: 18px;
-      height: 18px;
-      margin-top: -5px;
+      appearance: none;
+      width: 16px;
+      height: 16px;
       border-radius: 50%;
+      border: 2px solid rgba(0, 255, 255, 0.8);
       background: #ffffff;
-      border: 2px solid rgba(0, 255, 255, 0.85);
-      box-shadow: 0 0 18px rgba(0, 255, 255, 0.6);
+      box-shadow: 0 0 14px rgba(0, 255, 255, 0.6);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
+      margin-top: -6px;
     }
 
     .star-ctl-slider input[type=range]:active::-webkit-slider-thumb {
-      transform: scale(1.1);
-      box-shadow: 0 0 22px rgba(153, 69, 255, 0.65);
+      transform: scale(0.9);
+      box-shadow: 0 0 20px rgba(153, 69, 255, 0.6);
     }
 
     .star-ctl-slider input[type=range]::-moz-range-track {
-      height: 8px;
+      height: 4px;
       background: transparent;
     }
 
     .star-ctl-slider input[type=range]::-moz-range-thumb {
-      width: 18px;
-      height: 18px;
+      width: 16px;
+      height: 16px;
       border-radius: 50%;
+      border: 2px solid rgba(0, 255, 255, 0.8);
       background: #ffffff;
-      border: 2px solid rgba(0, 255, 255, 0.85);
-      box-shadow: 0 0 18px rgba(0, 255, 255, 0.6);
+      box-shadow: 0 0 14px rgba(0, 255, 255, 0.6);
       transition: transform 0.2s ease, box-shadow 0.2s ease;
     }
-    
+
+    .star-ctl-slider input[type=range]:active::-moz-range-thumb {
+      transform: scale(0.9);
+      box-shadow: 0 0 20px rgba(153, 69, 255, 0.6);
+    }
+
     /* Main Container */
     .wrap {
       position: relative;
@@ -709,6 +668,138 @@
       text-transform: uppercase;
       letter-spacing: 3px;
       text-shadow: 0 0 10px currentColor;
+    }
+
+    .dom-detail {
+      display: flex;
+      flex-direction: column;
+      gap: 16px;
+    }
+
+    .dom-rows {
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+    }
+
+    .dom-row {
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      padding: 8px 12px;
+      border-radius: 12px;
+      border: 1px solid rgba(0, 255, 255, 0.12);
+      background: linear-gradient(135deg, rgba(0, 255, 255, 0.08), rgba(153, 69, 255, 0.05));
+      font-family: 'Orbitron', monospace;
+      text-transform: uppercase;
+      letter-spacing: 1.4px;
+    }
+
+    .dom-dot {
+      width: 10px;
+      height: 10px;
+      border-radius: 50%;
+      background: var(--dom-color, #00ffff);
+      box-shadow: 0 0 12px var(--dom-color, rgba(0, 255, 255, 0.6));
+    }
+
+    .dom-row .dom-name {
+      flex: 1;
+      font-weight: 700;
+      color: rgba(0, 255, 255, 0.92);
+      text-shadow: 0 0 10px currentColor;
+    }
+
+    .dom-row .dom-symbol {
+      font-size: 0.65rem;
+      opacity: 0.7;
+      margin-left: 6px;
+      letter-spacing: 1.6px;
+    }
+
+    .dom-value {
+      font-variant-numeric: tabular-nums;
+      font-weight: 700;
+      min-width: 72px;
+      text-align: right;
+    }
+
+    .dom-delta {
+      font-variant-numeric: tabular-nums;
+      min-width: 82px;
+      text-align: right;
+      font-weight: 600;
+    }
+
+    .dom-delta.up {
+      color: var(--up);
+      text-shadow: 0 0 8px currentColor;
+    }
+
+    .dom-delta.down {
+      color: var(--down);
+      text-shadow: 0 0 8px currentColor;
+    }
+
+    .dom-delta.neutral {
+      color: rgba(255, 255, 255, 0.6);
+    }
+
+    .dom-chart {
+      position: relative;
+      padding: 12px;
+      border-radius: 16px;
+      border: 1px solid rgba(0, 255, 255, 0.12);
+      background: linear-gradient(135deg, rgba(0, 255, 255, 0.06), rgba(15, 18, 38, 0.75));
+      box-shadow: 0 12px 28px rgba(4, 12, 24, 0.45);
+    }
+
+    .dom-chart canvas {
+      display: block;
+      width: 100%;
+      height: 140px;
+    }
+
+    .dom-link {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 8px;
+      padding: 8px 14px;
+      border-radius: 12px;
+      border: 1px solid rgba(0, 255, 255, 0.35);
+      background: rgba(0, 255, 255, 0.08);
+      color: #00ffff;
+      font-family: 'Orbitron', monospace;
+      font-size: 0.72rem;
+      letter-spacing: 1.6px;
+      text-transform: uppercase;
+      text-decoration: none;
+      transition: border-color 0.25s ease, box-shadow 0.25s ease;
+    }
+
+    .dom-link:hover,
+    .dom-link:focus-visible {
+      border-color: rgba(0, 255, 255, 0.6);
+      box-shadow: 0 0 18px rgba(0, 255, 255, 0.25);
+      outline: none;
+    }
+
+    .dom-link.disabled {
+      color: rgba(255, 255, 255, 0.45);
+      border-color: rgba(255, 255, 255, 0.12);
+      background: rgba(0, 0, 0, 0.25);
+      cursor: default;
+      pointer-events: none;
+      box-shadow: none;
+    }
+
+    .dom-empty {
+      font-family: 'Orbitron', monospace;
+      font-size: 0.75rem;
+      letter-spacing: 1.6px;
+      text-transform: uppercase;
+      color: rgba(255, 255, 255, 0.6);
     }
     
     /* Controls */
@@ -1021,18 +1112,12 @@
 
       /* Star controller - smaller on mobile */
       .star-ctl {
-        margin: 6px 0 22px;
-        width: 100%;
-        justify-content: space-between;
-        padding: 14px 16px;
-      }
-
-      .star-ctl-meta {
-        flex: 1 1 auto;
+        margin: 12px auto 24px;
+        padding: 8px 14px;
       }
 
       .star-ctl-slider {
-        min-width: 100%;
+        width: clamp(140px, 60vw, 220px);
       }
       
       /* Hub adjustments */
@@ -1057,7 +1142,16 @@
       .seg-label {
         font-size: 12px;
       }
-      
+
+      .dom-row {
+        flex-wrap: wrap;
+      }
+
+      .dom-value,
+      .dom-delta {
+        min-width: auto;
+      }
+
       .hub-panel {
         min-height: 200px;
         padding: 16px;
@@ -1169,31 +1263,29 @@
       }
       
       .wrap {
-        padding: 90px 8px 40px;
+        padding: 110px 8px 40px;
       }
 
       .nav-container {
         padding: 12px 16px;
       }
 
-      .nav-right {
-        gap: 8px;
-        flex-wrap: wrap;
-        justify-content: flex-start;
-      }
-
       .star-ctl {
-        width: 100%;
-        padding: 12px 14px;
-        gap: 14px;
-      }
-
-      .star-ctl-value {
-        font-size: 0.78rem;
+        margin: 10px auto 20px;
+        padding: 8px 12px;
       }
 
       .star-ctl-slider {
-        min-width: 100%;
+        width: clamp(150px, 70vw, 220px);
+      }
+
+      .dom-row {
+        gap: 8px;
+      }
+
+      .dom-value,
+      .dom-delta {
+        font-size: 0.72rem;
       }
 
       /* Even smaller hub on very small screens */
@@ -1355,28 +1447,18 @@
           <li><a href="/menu/auth/login/" data-tooltip="포털">Portal</a></li>
         </ul>
       </div>
-      <div class="nav-right">
-        <span>Cosmos Deck</span>
-        <span>Auto refresh 30s</span>
-      </div>
     </div>
   </nav>
 
   <div class="wrap">
     <!-- Star Controller -->
     <div class="star-ctl" aria-label="Star background controller">
-      <label class="star-ctl-meta" for="starRange" id="starRangeLabel">
-        <span class="star-ctl-icon" aria-hidden="true">✦</span>
-        <span class="star-ctl-copy">
-          <span class="star-ctl-title">Starfield Density</span>
-          <span class="star-ctl-value" id="starValue" aria-live="polite">80%</span>
-        </span>
-      </label>
+      <span id="starValue" class="sr-only" aria-live="polite">80%</span>
       <div class="star-ctl-slider">
         <div class="star-ctl-track" aria-hidden="true">
           <span class="star-ctl-progress" style="width:80%"></span>
         </div>
-        <input id="starRange" type="range" min="0" max="100" value="80" aria-labelledby="starRangeLabel" aria-describedby="starValue" />
+        <input id="starRange" type="range" min="0" max="100" value="80" aria-label="Starfield density" aria-describedby="starValue" />
       </div>
     </div>
 
@@ -1429,7 +1511,7 @@
     
     <div id="pager" class="controls"></div>
     
-    <footer>Cosmos Dashboard · Powered by CoinGecko · Alternative.me · Auto refresh 30s</footer>
+    <footer>Cosmos Dashboard · Powered by CoinGecko · Alternative.me</footer>
   </div>
   
   <!-- JavaScript 파일 로드 -->


### PR DESCRIPTION
## Summary
- add lifecycle helpers that reset and re-render the dominance sparkline canvas when the panel changes size
- schedule multiple draw attempts and hook a resize observer so the BTC/ETH/XRP multi-line chart reliably appears when the dominance panel opens

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d498c9c66c832f9d483b771da34341