### PR TITLE
Fix dominance chart timestamp handling

### DIFF
--- a/server.js
+++ b/server.js
@@ -983,7 +983,8 @@ app.get('/api/dominance/top3', async (req, res) => {
     const normalizeTs = (ts) => {
       const n = Number(ts);
       if (!Number.isFinite(n)) return null;
-      return Math.round(n / 3_600_000) * 3_600_000; // hourly bucket
+      const ms = n >= 1e12 ? n : n * 1000; // CoinGecko global chart uses seconds
+      return Math.round(ms / 3_600_000) * 3_600_000; // hourly bucket in ms
     };
 
     const totalMap = new Map();


### PR DESCRIPTION
## Summary
- normalize dominance API timestamps so CoinGecko's second-based values are converted to milliseconds before bucketing
- ensure market dominance multi chart receives aligned data for sparkline rendering

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4a6ceb3d8832fb2f41bcc4ac97f23