### PR TITLE
feat: add cosmic liquidity and CVD dashboard

### DIFF
--- a/apps/web/menu/cosmos/cvd-heatmap.css
+++ b/apps/web/menu/cosmos/cvd-heatmap.css
@@ -1,0 +1,288 @@
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: 'Rajdhani', sans-serif;
+  color: #e2ebff;
+  background: radial-gradient(circle at 20% 20%, rgba(22, 15, 52, 0.95), rgba(4, 6, 18, 0.95)),
+              radial-gradient(circle at 80% 10%, rgba(12, 32, 68, 0.75), rgba(2, 5, 18, 0.85)),
+              #04030f;
+  position: relative;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) calc(env(safe-area-inset-bottom) + 32px) env(safe-area-inset-left);
+  overflow-x: hidden;
+}
+
+.nebula-overlay {
+  position: fixed;
+  inset: 0;
+  background-image: radial-gradient(circle at 15% 25%, rgba(114, 41, 255, 0.2), transparent 55%),
+                    radial-gradient(circle at 80% 20%, rgba(255, 0, 153, 0.18), transparent 50%),
+                    radial-gradient(circle at 30% 75%, rgba(0, 255, 255, 0.1), transparent 55%);
+  pointer-events: none;
+  animation: nebula-flow 30s linear infinite alternate;
+  z-index: 0;
+}
+
+@keyframes nebula-flow {
+  0% { transform: scale(1) translate(0, 0); filter: hue-rotate(0deg); }
+  50% { transform: scale(1.05) translate(-1%, -1%); filter: hue-rotate(20deg); }
+  100% { transform: scale(1.02) translate(1%, 1%); filter: hue-rotate(-15deg); }
+}
+
+.dashboard-header {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  gap: 24px;
+  padding: 32px clamp(16px, 4vw, 48px) 16px;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 238, 255, 0.4);
+  color: #9be8ff;
+  text-decoration: none;
+  font-family: 'Orbitron', sans-serif;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  transition: background 0.3s ease, box-shadow 0.3s ease, color 0.3s ease;
+  background: rgba(12, 20, 44, 0.4);
+}
+
+.back-link:hover,
+.back-link:focus-visible {
+  outline: none;
+  background: rgba(0, 187, 255, 0.15);
+  color: #ffffff;
+  box-shadow: 0 0 20px rgba(0, 238, 255, 0.35);
+}
+
+.header-title h1 {
+  margin: 0;
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(28px, 3vw, 40px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #f7faff;
+  text-shadow: 0 0 18px rgba(98, 192, 255, 0.4);
+}
+
+.header-title p {
+  margin: 6px 0 0;
+  font-size: 15px;
+  color: rgba(209, 224, 255, 0.78);
+  letter-spacing: 0.02em;
+}
+
+.dashboard-main {
+  position: relative;
+  z-index: 1;
+  max-width: 1280px;
+  margin: 0 auto;
+  padding: 0 clamp(16px, 4vw, 48px) 64px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.panel {
+  background: linear-gradient(135deg, rgba(8, 16, 36, 0.78), rgba(20, 12, 40, 0.82));
+  border-radius: 28px;
+  border: 1px solid rgba(92, 225, 230, 0.25);
+  box-shadow: 0 30px 60px rgba(5, 11, 32, 0.55), inset 0 0 60px rgba(24, 69, 99, 0.18);
+  padding: clamp(20px, 3vw, 32px);
+  backdrop-filter: blur(18px);
+  position: relative;
+  overflow: hidden;
+}
+
+.panel::before {
+  content: '';
+  position: absolute;
+  inset: -40%;
+  background: radial-gradient(circle, rgba(0, 255, 255, 0.08), transparent 70%);
+  transform: rotate(12deg);
+  opacity: 0.7;
+  pointer-events: none;
+}
+
+.panel-header {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 18px 24px;
+  position: relative;
+  z-index: 1;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(22px, 2.4vw, 28px);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #b8f3ff;
+}
+
+.panel-description {
+  margin: 6px 0 0;
+  font-size: 14px;
+  color: rgba(200, 220, 255, 0.75);
+  letter-spacing: 0.02em;
+}
+
+.panel-meta {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px 18px;
+  align-items: center;
+  min-width: 280px;
+}
+
+.panel-meta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 13px;
+}
+
+.meta-label {
+  color: rgba(182, 205, 255, 0.6);
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.meta-value {
+  font-size: 15px;
+  font-weight: 600;
+  color: #f2f6ff;
+}
+
+.meta-value.neon {
+  color: #72faff;
+  text-shadow: 0 0 14px rgba(0, 255, 255, 0.4);
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: rgba(40, 54, 88, 0.5);
+  color: #d1e4ff;
+  transition: all 0.3s ease;
+}
+
+.status-pill[data-status-state="online"] {
+  background: rgba(34, 197, 94, 0.2);
+  border-color: rgba(34, 197, 94, 0.45);
+  color: #7bffca;
+  box-shadow: 0 0 18px rgba(34, 197, 94, 0.32);
+}
+
+.status-pill[data-status-state="error"] {
+  background: rgba(255, 56, 122, 0.16);
+  border-color: rgba(255, 56, 122, 0.4);
+  color: #ff99c8;
+  box-shadow: 0 0 20px rgba(255, 66, 66, 0.3);
+}
+
+.status-pill[data-status-state="loading"] {
+  background: rgba(79, 70, 229, 0.22);
+  border-color: rgba(129, 140, 248, 0.4);
+  color: #c7d2fe;
+  box-shadow: 0 0 16px rgba(99, 102, 241, 0.28);
+}
+
+.panel-hints {
+  align-self: flex-end;
+  font-size: 13px;
+  color: rgba(198, 209, 255, 0.7);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.chart {
+  position: relative;
+  margin-top: 20px;
+  height: 420px;
+  border-radius: 20px;
+  overflow: hidden;
+}
+
+.cvd-panel .chart {
+  height: 360px;
+}
+
+.dashboard-footer {
+  position: relative;
+  z-index: 1;
+  text-align: center;
+  font-size: 13px;
+  color: rgba(180, 204, 255, 0.6);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+  .panel-meta {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .dashboard-main {
+    padding-bottom: 48px;
+  }
+}
+
+@media (max-width: 768px) {
+  .dashboard-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .panel {
+    border-radius: 22px;
+    padding: 20px;
+  }
+
+  .chart {
+    height: 360px;
+  }
+
+  .cvd-panel .chart {
+    height: 320px;
+  }
+}
+
+@media (max-width: 480px) {
+  .panel-meta {
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+  }
+
+  .header-title h1 {
+    font-size: 24px;
+  }
+
+  .header-title p {
+    font-size: 13px;
+  }
+}

--- a/apps/web/menu/cosmos/cvd-heatmap.html
+++ b/apps/web/menu/cosmos/cvd-heatmap.html
@@ -1,0 +1,76 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#05030f" />
+  <title>TWO.4 · Cosmic Liquidity &amp; CVD</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Rajdhani:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./cvd-heatmap.css" />
+</head>
+<body>
+  <div class="nebula-overlay" aria-hidden="true"></div>
+  <header class="dashboard-header">
+    <a class="back-link" href="/menu/cosmos/">
+      <span aria-hidden="true">⭠</span>
+      <span>Cosmos Hub</span>
+    </a>
+    <div class="header-title">
+      <h1>Cosmic Liquidity Matrix</h1>
+      <p>Binance BTCUSDT · Futures Orderbook heatmap + CVD bands · 우주 네온 감성</p>
+    </div>
+  </header>
+
+  <main class="dashboard-main">
+    <section class="panel heatmap-panel" aria-labelledby="heatmapTitle">
+      <div class="panel-header">
+        <div>
+          <h2 id="heatmapTitle">Liquidity Heatmap</h2>
+          <p class="panel-description">30초 스냅샷으로 구성된 가격-시간 유동성 히트맵 · 파란선은 실시간 중간가</p>
+        </div>
+        <div class="panel-meta">
+          <div>
+            <span class="meta-label">Symbol</span>
+            <span class="meta-value neon" data-symbol>BTCUSDT</span>
+          </div>
+          <div>
+            <span class="meta-label">Last Price</span>
+            <span class="meta-value" data-price>--</span>
+          </div>
+          <div>
+            <span class="meta-label">Last Update</span>
+            <span class="meta-value" data-updated>--</span>
+          </div>
+          <div>
+            <span class="meta-label">Stream</span>
+            <span class="status-pill" data-status data-status-state="idle">Initializing</span>
+          </div>
+        </div>
+      </div>
+      <div class="chart" id="heatmapChart" role="img" aria-label="Heatmap of liquidity"></div>
+    </section>
+
+    <section class="panel cvd-panel" aria-labelledby="cvdTitle">
+      <div class="panel-header">
+        <div>
+          <h2 id="cvdTitle">Neon CVD Bands</h2>
+          <p class="panel-description">1분 누적 매수·매도 델타 · 주문규모별 5개 밴드 + 전체 누적</p>
+        </div>
+        <div class="panel-hints">
+          <span>범례 클릭으로 라인 on/off · 드래그로 줌 · 상단 히트맵과 시간축 연동</span>
+        </div>
+      </div>
+      <div class="chart" id="cvdChart" role="img" aria-label="CVD lines by notional size"></div>
+    </section>
+  </main>
+
+  <footer class="dashboard-footer">
+    Data from Binance WebSocket · Aggregated &amp; cached in SQLite · Crafted for TWO.4 Cosmos
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
+  <script src="./cvd-heatmap.js" defer></script>
+</body>
+</html>

--- a/apps/web/menu/cosmos/cvd-heatmap.js
+++ b/apps/web/menu/cosmos/cvd-heatmap.js
@@ -1,0 +1,380 @@
+(function () {
+  'use strict';
+
+  const symbol = 'BTCUSDT';
+  const heatmapEl = document.getElementById('heatmapChart');
+  const cvdEl = document.getElementById('cvdChart');
+  const statusEl = document.querySelector('[data-status]');
+  const updatedEl = document.querySelector('[data-updated]');
+  const priceEl = document.querySelector('[data-price]');
+  const symbolEl = document.querySelector('[data-symbol]');
+
+  if (symbolEl) {
+    symbolEl.textContent = symbol;
+  }
+
+  if (!heatmapEl || !cvdEl) {
+    console.error('Dashboard elements are missing.');
+    return;
+  }
+
+  const heatmapChart = echarts.init(heatmapEl);
+  const cvdChart = echarts.init(cvdEl);
+  echarts.connect([heatmapChart, cvdChart]);
+
+  const bucketColors = {
+    all: '#00f5ff',
+    bucket0: '#22d3ee',
+    bucket1: '#8b5cf6',
+    bucket2: '#ec4899',
+    bucket3: '#facc15',
+    bucket4: '#fb7185',
+  };
+
+  function setStatus(state, label) {
+    if (!statusEl) return;
+    statusEl.dataset.statusState = state;
+    statusEl.textContent = label;
+  }
+
+  function formatNumber(value) {
+    if (value == null || Number.isNaN(value)) {
+      return '--';
+    }
+    const abs = Math.abs(value);
+    if (abs >= 1e9) return `${(value / 1e9).toFixed(2)}B`;
+    if (abs >= 1e6) return `${(value / 1e6).toFixed(2)}M`;
+    if (abs >= 1e3) return `${(value / 1e3).toFixed(2)}K`;
+    if (abs >= 1) return value.toFixed(2);
+    return value.toFixed(4);
+  }
+
+  function formatCurrency(value) {
+    if (value == null || Number.isNaN(value)) {
+      return '--';
+    }
+    return `$${Number(value).toLocaleString(undefined, { maximumFractionDigits: 2 })}`;
+  }
+
+  function formatTimestamp(ts) {
+    if (!Number.isFinite(ts)) return '--';
+    const date = new Date(ts);
+    return `${date.getHours().toString().padStart(2, '0')}:${date
+      .getMinutes()
+      .toString()
+      .padStart(2, '0')}`;
+  }
+
+  function formatTimestampLong(ts) {
+    if (!Number.isFinite(ts)) return '--';
+    const date = new Date(ts);
+    return `${date.getFullYear()}-${(date.getMonth() + 1)
+      .toString()
+      .padStart(2, '0')}-${date.getDate().toString().padStart(2, '0')} ${date
+      .getHours()
+      .toString()
+      .padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')}`;
+  }
+
+  async function fetchJson(url) {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Request failed: ${response.status}`);
+    }
+    return response.json();
+  }
+
+  function buildHeatmapOption(heatmap, priceSeries) {
+    if (
+      !heatmap ||
+      !Array.isArray(heatmap.timestamps) ||
+      !Array.isArray(heatmap.matrix) ||
+      heatmap.timestamps.length === 0 ||
+      heatmap.matrix.length === 0
+    ) {
+      return null;
+    }
+
+    const centers = (heatmap.priceBins && heatmap.priceBins.centers) || [];
+    const heatmapData = [];
+
+    heatmap.matrix.forEach((row, rowIndex) => {
+      const ts = heatmap.timestamps[rowIndex];
+      if (!Number.isFinite(ts) || !Array.isArray(row)) return;
+      row.forEach((value, colIndex) => {
+        const price = centers[colIndex];
+        if (!Number.isFinite(price) || !Number.isFinite(value)) return;
+        heatmapData.push([ts, price, Number(value)]);
+      });
+    });
+
+    const rangeStart = heatmap.timestamps[0];
+    const rangeEnd = heatmap.timestamps[heatmap.timestamps.length - 1];
+    const filteredPriceSeries = Array.isArray(priceSeries)
+      ? priceSeries
+          .filter((point) =>
+            point && Number.isFinite(point.timestamp) && Number.isFinite(point.price)
+              ? (!Number.isFinite(rangeStart) || point.timestamp >= rangeStart) &&
+                (!Number.isFinite(rangeEnd) || point.timestamp <= rangeEnd)
+              : false
+          )
+          .map((point) => [point.timestamp, point.price])
+      : [];
+
+    const maxValue = Math.max(heatmap.maxValue || 0, 1);
+
+    return {
+      backgroundColor: 'transparent',
+      grid: { left: 70, right: 110, top: 80, bottom: 60 },
+      tooltip: {
+        trigger: 'item',
+        borderColor: '#1b3455',
+        backgroundColor: 'rgba(10, 20, 40, 0.9)',
+        borderWidth: 1,
+        formatter(params) {
+          if (!params || !params.value) return '';
+          const [ts, price, value] = params.value;
+          return [
+            `<div class="tooltip-title">${formatTimestampLong(ts)}</div>`,
+            `<div>Price&nbsp;<strong>${formatCurrency(price)}</strong></div>`,
+            `<div>Liquidity&nbsp;<strong>${formatNumber(value)} USDT</strong></div>`,
+          ].join('');
+        },
+      },
+      visualMap: {
+        min: 0,
+        max: maxValue,
+        calculable: true,
+        orient: 'vertical',
+        right: 18,
+        top: 'center',
+        text: ['HIGH', 'LOW'],
+        itemHeight: 200,
+        textStyle: {
+          color: '#d0e4ff',
+          fontFamily: 'Rajdhani, sans-serif',
+          letterSpacing: 3,
+        },
+        inRange: {
+          color: ['#140020', '#31004c', '#5a007a', '#9c0060', '#ff3d00', '#ffe45c'],
+        },
+      },
+      xAxis: {
+        type: 'time',
+        axisLabel: {
+          color: '#7dd3fc',
+          fontSize: 12,
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(70, 110, 150, 0.5)' },
+        },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          color: '#a5b4fc',
+          formatter: (value) => formatCurrency(value),
+        },
+        axisLine: {
+          lineStyle: { color: 'rgba(70, 110, 150, 0.45)' },
+        },
+        splitLine: {
+          lineStyle: { color: 'rgba(90, 118, 180, 0.18)', type: 'dashed' },
+        },
+      },
+      axisPointer: {
+        link: [{ xAxisIndex: [0] }],
+        label: { backgroundColor: 'rgba(18, 32, 64, 0.8)', borderColor: '#00f5ff', borderWidth: 1 },
+      },
+      dataZoom: [
+        { type: 'inside', zoomLock: false },
+        {
+          type: 'slider',
+          height: 20,
+          bottom: 10,
+          backgroundColor: 'rgba(12, 22, 42, 0.6)',
+          borderColor: 'rgba(0, 255, 255, 0.2)',
+          fillerColor: 'rgba(0, 255, 255, 0.25)',
+          handleStyle: { color: '#22d3ee' },
+          textStyle: { color: '#9bd9ff' },
+        },
+      ],
+      series: [
+        {
+          name: 'Liquidity Heatmap',
+          type: 'heatmap',
+          data: heatmapData,
+          progressive: 0,
+          emphasis: { itemStyle: { borderColor: '#00f5ff', borderWidth: 1 } },
+        },
+        {
+          name: 'Price',
+          type: 'line',
+          data: filteredPriceSeries,
+          smooth: true,
+          showSymbol: false,
+          lineStyle: { color: '#3ab4ff', width: 2.2 },
+          tooltip: { show: false },
+        },
+      ],
+      textStyle: {
+        fontFamily: 'Rajdhani, sans-serif',
+      },
+    };
+  }
+
+  function buildCvdOption(cvd) {
+    if (!cvd || !Array.isArray(cvd.points) || !Array.isArray(cvd.buckets)) {
+      return null;
+    }
+
+    const legendNames = [];
+    const series = [];
+
+    cvd.buckets.forEach((bucket) => {
+      const key = bucket.key;
+      const name = bucket.label || key;
+      legendNames.push(name);
+      const data = cvd.points
+        .filter((point) => point && Number.isFinite(point.timestamp))
+        .map((point) => [point.timestamp, point.values ? Number(point.values[key]) : 0]);
+      series.push({
+        name,
+        type: 'line',
+        data,
+        smooth: true,
+        showSymbol: false,
+        lineStyle: {
+          width: key === 'all' ? 2.8 : 2.2,
+          color: bucketColors[key] || '#60a5fa',
+        },
+        emphasis: {
+          focus: 'series',
+        },
+        areaStyle: key === 'all'
+          ? {
+              color: 'rgba(0, 245, 255, 0.08)',
+            }
+          : undefined,
+      });
+    });
+
+    return {
+      backgroundColor: 'transparent',
+      legend: {
+        top: 16,
+        textStyle: { color: '#dbe7ff', fontSize: 13, fontFamily: 'Rajdhani, sans-serif' },
+        icon: 'circle',
+        itemWidth: 14,
+        itemHeight: 14,
+        data: legendNames,
+      },
+      grid: { left: 70, right: 30, top: 80, bottom: 60 },
+      tooltip: {
+        trigger: 'axis',
+        axisPointer: { type: 'cross' },
+        borderColor: '#1b3455',
+        backgroundColor: 'rgba(10, 20, 40, 0.9)',
+        valueFormatter: (value) => `${formatNumber(value)} USDT`,
+      },
+      xAxis: {
+        type: 'time',
+        axisLabel: { color: '#9eb5ff', fontSize: 12 },
+        axisLine: { lineStyle: { color: 'rgba(70, 110, 150, 0.4)' } },
+        splitLine: { show: false },
+      },
+      yAxis: {
+        type: 'value',
+        axisLabel: {
+          color: '#c7d2fe',
+          formatter: (value) => `${formatNumber(value)} USDT`,
+        },
+        axisLine: { lineStyle: { color: 'rgba(70, 110, 150, 0.4)' } },
+        splitLine: { lineStyle: { color: 'rgba(90, 118, 180, 0.18)', type: 'dashed' } },
+      },
+      axisPointer: {
+        link: [{ xAxisIndex: 'all' }],
+        label: { backgroundColor: 'rgba(18, 32, 64, 0.8)', borderColor: '#00f5ff', borderWidth: 1 },
+      },
+      dataZoom: [
+        { type: 'inside' },
+        {
+          type: 'slider',
+          height: 20,
+          bottom: 10,
+          backgroundColor: 'rgba(12, 22, 42, 0.6)',
+          borderColor: 'rgba(0, 255, 255, 0.2)',
+          fillerColor: 'rgba(131, 24, 255, 0.25)',
+          handleStyle: { color: '#f472b6' },
+          textStyle: { color: '#f1c4ff' },
+        },
+      ],
+      series,
+      textStyle: {
+        fontFamily: 'Rajdhani, sans-serif',
+      },
+    };
+  }
+
+  function updateMetadata({ cvd, heatmap, price }) {
+    if (priceEl) {
+      const current = price && price.meta && Number.isFinite(price.meta.lastPrice)
+        ? price.meta.lastPrice
+        : heatmap && Number.isFinite(heatmap.lastPrice)
+          ? heatmap.lastPrice
+          : null;
+      priceEl.textContent = current ? formatCurrency(current) : '--';
+    }
+
+    if (updatedEl) {
+      const timestamps = [];
+      if (cvd && Number.isFinite(cvd.meta?.lastTimestamp)) {
+        timestamps.push(cvd.meta.lastTimestamp);
+      }
+      if (Array.isArray(heatmap?.timestamps) && heatmap.timestamps.length) {
+        timestamps.push(heatmap.timestamps[heatmap.timestamps.length - 1]);
+      }
+      if (Array.isArray(price?.points) && price.points.length) {
+        timestamps.push(price.points[price.points.length - 1].timestamp);
+      }
+      const latest = timestamps.length ? Math.max(...timestamps) : null;
+      updatedEl.textContent = latest ? formatTimestampLong(latest) : '--';
+    }
+  }
+
+  async function loadData(isRefresh) {
+    try {
+      setStatus('loading', isRefresh ? 'Refreshing…' : 'Loading…');
+      const [heatmap, cvd, price] = await Promise.all([
+        fetchJson(`/api/heatmap?symbol=${symbol}&bins=120&limit=720`),
+        fetchJson(`/api/cvd?symbol=${symbol}&tf=1m&limit=1440`),
+        fetchJson(`/api/price?symbol=${symbol}&tf=1m&limit=1440`),
+      ]);
+
+      const heatmapOption = buildHeatmapOption(heatmap, price.points);
+      const cvdOption = buildCvdOption(cvd);
+
+      if (heatmapOption) {
+        heatmapChart.setOption(heatmapOption, true);
+      }
+      if (cvdOption) {
+        cvdChart.setOption(cvdOption, true);
+      }
+
+      updateMetadata({ cvd, heatmap, price });
+      setStatus('online', 'Online');
+    } catch (error) {
+      console.error('Failed to refresh dashboard:', error);
+      setStatus('error', 'Error');
+    }
+  }
+
+  window.addEventListener('resize', () => {
+    heatmapChart.resize();
+    cvdChart.resize();
+  });
+
+  loadData(false);
+  setInterval(() => loadData(true), 60_000);
+})();

--- a/apps/web/menu/cosmos/index.html
+++ b/apps/web/menu/cosmos/index.html
@@ -871,6 +871,24 @@
       font-size: 0.55rem;
       letter-spacing: 1.2px;
     }
+
+    .twofive-link.neon-dashboard-link {
+      border-color: rgba(109, 40, 217, 0.6);
+      background: linear-gradient(135deg, rgba(76, 29, 149, 0.55), rgba(13, 148, 136, 0.45));
+      box-shadow: 0 18px 42px rgba(56, 189, 248, 0.28);
+    }
+
+    .twofive-link.neon-dashboard-link .twofive-link__icon {
+      background: rgba(56, 189, 248, 0.22);
+      color: #f0f9ff;
+      box-shadow: 0 0 18px rgba(14, 165, 233, 0.45);
+    }
+
+    .twofive-link.neon-dashboard-link .twofive-link__badge {
+      background: linear-gradient(135deg, rgba(244, 114, 182, 0.8), rgba(96, 165, 250, 0.8));
+      border-color: rgba(255, 255, 255, 0.35);
+      color: #fff7c2;
+    }
     
     input[type=text] {
       width: 100%;
@@ -1554,6 +1572,15 @@
         <span class="twofive-link__meta">
           <span>Two.5 Sector Map</span>
           <span class="twofive-link__badge">LIVE</span>
+        </span>
+      </a>
+      <a class="twofive-link neon-dashboard-link" href="/menu/cosmos/cvd-heatmap.html"
+         title="Cosmic Liquidity &amp; CVD Dashboard"
+         aria-label="Cosmic Liquidity &amp; CVD Dashboard 바로가기">
+        <span class="twofive-link__icon" aria-hidden="true">🛰️</span>
+        <span class="twofive-link__meta">
+          <span>Cosmic Liquidity</span>
+          <span class="twofive-link__badge">NEW</span>
         </span>
       </a>
       <input class="search" id="q" type="text" placeholder="🔍 Search cryptocurrency (name/symbol)">

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "cookie-parser": "^1.4.6",
     "node-fetch": "^2.6.9",
     "mongoose": "^8.6.0",
-    "rss-parser": "^3.12.0"
+    "rss-parser": "^3.12.0",
+    "sqlite3": "^5.1.7",
+    "ws": "^8.17.0"
   },
   "engines": {
     "node": "18.x"

--- a/server/api/cvd.js
+++ b/server/api/cvd.js
@@ -1,0 +1,64 @@
+const express = require('express');
+const { BUCKETS } = require('../engines/cvdEngine');
+
+function formatBuckets() {
+  return [
+    { key: 'all', label: 'All Orders' },
+    ...BUCKETS.map((bucket) => ({
+      key: bucket.key,
+      label: bucket.label,
+      range: [bucket.min, Number.isFinite(bucket.max) ? bucket.max : null],
+    })),
+  ];
+}
+
+module.exports = function createCvdRouter({ cvdEngine }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res) => {
+    const symbol = (req.query.symbol || cvdEngine.symbol || 'BTCUSDT').toUpperCase();
+    const timeframe = String(req.query.tf || '1m');
+    const limit = Math.min(10_000, Math.max(10, Number.parseInt(req.query.limit, 10) || 1440));
+
+    if (timeframe !== '1m') {
+      return res.status(400).json({ error: 'Only 1m timeframe is supported for now.' });
+    }
+
+    if (symbol !== cvdEngine.symbol) {
+      return res.status(404).json({ error: 'Symbol not tracked yet.' });
+    }
+
+    try {
+      const rows = await cvdEngine.getHistory({ limit });
+      const buckets = formatBuckets();
+      const payload = rows.map((row) => ({
+        timestamp: row.minute,
+        values: {
+          all: row.total,
+          bucket0: row.bucket0,
+          bucket1: row.bucket1,
+          bucket2: row.bucket2,
+          bucket3: row.bucket3,
+          bucket4: row.bucket4,
+        },
+        price: row.price,
+      }));
+
+      return res.json({
+        symbol,
+        timeframe,
+        buckets,
+        points: payload,
+        meta: {
+          lastPrice: rows.length ? rows[rows.length - 1].price : null,
+          lastTimestamp: rows.length ? rows[rows.length - 1].minute : null,
+        },
+      });
+    } catch (error) {
+      console.error('[API/CVD] Failed to load history:', error.message);
+      return res.status(500).json({ error: 'Failed to load CVD history.' });
+    }
+  });
+
+  return router;
+};

--- a/server/api/heatmap.js
+++ b/server/api/heatmap.js
@@ -1,0 +1,127 @@
+const express = require('express');
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+module.exports = function createHeatmapRouter({ heatmapEngine }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res) => {
+    const symbol = (req.query.symbol || heatmapEngine.symbol || 'BTCUSDT').toUpperCase();
+    const bins = clamp(Number.parseInt(req.query.bins, 10) || 120, 10, 500);
+    const limit = clamp(Number.parseInt(req.query.limit, 10) || 720, 10, 2000);
+
+    if (symbol !== heatmapEngine.symbol) {
+      return res.status(404).json({ error: 'Symbol not tracked yet.' });
+    }
+
+    try {
+      const rows = await heatmapEngine.getSnapshots({ limit });
+      if (!rows.length) {
+        return res.json({
+          symbol,
+          timestamps: [],
+          matrix: [],
+          priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+          maxValue: 0,
+          lastPrice: heatmapEngine.lastPrice,
+        });
+      }
+
+      const parsed = rows.map((row) => ({
+        timestamp: row.timestamp,
+        bids: JSON.parse(row.bids || '[]'),
+        asks: JSON.parse(row.asks || '[]'),
+        lastPrice: row.last_price,
+      }));
+
+      let minPrice = Number.POSITIVE_INFINITY;
+      let maxPrice = Number.NEGATIVE_INFINITY;
+      parsed.forEach((snapshot) => {
+        snapshot.bids.forEach(([price]) => {
+          const value = Number(price);
+          if (Number.isFinite(value)) {
+            minPrice = Math.min(minPrice, value);
+            maxPrice = Math.max(maxPrice, value);
+          }
+        });
+        snapshot.asks.forEach(([price]) => {
+          const value = Number(price);
+          if (Number.isFinite(value)) {
+            minPrice = Math.min(minPrice, value);
+            maxPrice = Math.max(maxPrice, value);
+          }
+        });
+      });
+
+      if (!Number.isFinite(minPrice) || !Number.isFinite(maxPrice)) {
+        return res.json({
+          symbol,
+          timestamps: [],
+          matrix: [],
+          priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+          maxValue: 0,
+          lastPrice: heatmapEngine.lastPrice,
+        });
+      }
+
+      if (minPrice === maxPrice) {
+        const padding = Math.max(1, minPrice * 0.001);
+        minPrice -= padding;
+        maxPrice += padding;
+      }
+
+      const range = maxPrice - minPrice;
+      const step = range > 0 ? range / bins : Math.max(1, minPrice * 0.001);
+      const centers = Array.from({ length: bins }, (_, idx) => minPrice + step * (idx + 0.5));
+
+      let globalMax = 0;
+      const matrix = parsed.map((snapshot) => {
+        const rowValues = new Array(bins).fill(0);
+        const accumulate = (levels) => {
+          levels.forEach(([price, qty]) => {
+            const priceNum = Number(price);
+            const qtyNum = Number(qty);
+            if (!Number.isFinite(priceNum) || !Number.isFinite(qtyNum)) {
+              return;
+            }
+            const index = Math.min(
+              bins - 1,
+              Math.max(0, Math.floor((priceNum - minPrice) / step))
+            );
+            const notional = Math.abs(priceNum * qtyNum);
+            rowValues[index] += notional;
+          });
+        };
+        accumulate(snapshot.bids);
+        accumulate(snapshot.asks);
+        const localMax = Math.max(...rowValues);
+        if (Number.isFinite(localMax)) {
+          globalMax = Math.max(globalMax, localMax);
+        }
+        return rowValues;
+      });
+
+      return res.json({
+        symbol,
+        timestamps: parsed.map((snapshot) => snapshot.timestamp),
+        matrix,
+        priceBins: {
+          count: bins,
+          min: minPrice,
+          max: maxPrice,
+          step,
+          centers,
+        },
+        maxValue: globalMax,
+        lastPrice: parsed[parsed.length - 1].lastPrice ?? heatmapEngine.lastPrice,
+      });
+    } catch (error) {
+      console.error('[API/HEATMAP] Failed to load snapshots:', error.message);
+      return res.status(500).json({ error: 'Failed to load heatmap data.' });
+    }
+  });
+
+  return router;
+};

--- a/server/api/price.js
+++ b/server/api/price.js
@@ -1,0 +1,41 @@
+const express = require('express');
+
+module.exports = function createPriceRouter({ cvdEngine }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res) => {
+    const symbol = (req.query.symbol || cvdEngine.symbol || 'BTCUSDT').toUpperCase();
+    const timeframe = String(req.query.tf || '1m');
+    const limit = Math.min(10_000, Math.max(10, Number.parseInt(req.query.limit, 10) || 1440));
+
+    if (timeframe !== '1m') {
+      return res.status(400).json({ error: 'Only 1m timeframe is supported for now.' });
+    }
+
+    if (symbol !== cvdEngine.symbol) {
+      return res.status(404).json({ error: 'Symbol not tracked yet.' });
+    }
+
+    try {
+      const rows = await cvdEngine.getPriceHistory({ limit });
+      const points = rows.map((row) => ({
+        timestamp: row.minute,
+        price: row.price,
+      }));
+
+      return res.json({
+        symbol,
+        timeframe,
+        points,
+        meta: {
+          lastPrice: rows.length ? rows[rows.length - 1].price : null,
+        },
+      });
+    } catch (error) {
+      console.error('[API/PRICE] Failed to load prices:', error.message);
+      return res.status(500).json({ error: 'Failed to load price history.' });
+    }
+  });
+
+  return router;
+};

--- a/server/database.js
+++ b/server/database.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const fs = require('fs');
+const sqlite3 = require('sqlite3').verbose();
+
+let dbInstance = null;
+
+function ensureDataDir() {
+  const dataDir = path.join(__dirname, '..', 'data');
+  fs.mkdirSync(dataDir, { recursive: true });
+  return dataDir;
+}
+
+function getDatabase() {
+  if (dbInstance) {
+    return dbInstance;
+  }
+
+  const dataDir = ensureDataDir();
+  const dbPath = path.join(dataDir, 'markets.sqlite');
+  dbInstance = new sqlite3.Database(dbPath);
+
+  dbInstance.serialize(() => {
+    dbInstance.run('PRAGMA journal_mode = WAL');
+  });
+
+  return dbInstance;
+}
+
+module.exports = {
+  getDatabase,
+};

--- a/server/engines/cvdEngine.js
+++ b/server/engines/cvdEngine.js
@@ -1,0 +1,305 @@
+const EventEmitter = require('events');
+const WebSocket = require('ws');
+
+const BUCKETS = [
+  { key: 'bucket0', label: '$0 - $10K', min: 0, max: 10_000 },
+  { key: 'bucket1', label: '$10K - $100K', min: 10_000, max: 100_000 },
+  { key: 'bucket2', label: '$100K - $1M', min: 100_000, max: 1_000_000 },
+  { key: 'bucket3', label: '$1M - $10M', min: 1_000_000, max: 10_000_000 },
+  { key: 'bucket4', label: '$10M+', min: 10_000_000, max: Infinity },
+];
+
+class CVDEngine extends EventEmitter {
+  constructor({ db, symbol }) {
+    super();
+    this.db = db;
+    this.symbol = symbol.toUpperCase();
+    this.symbolLower = this.symbol.toLowerCase();
+    this.ws = null;
+    this.connected = false;
+
+    this.currentMinute = null;
+    this.pending = this.createZeroBuckets();
+    this.pendingTotal = 0;
+    this.cumulative = this.createZeroBuckets();
+    this.cumulativeTotal = 0;
+    this.lastPrice = null;
+    this.lastTimestamp = null;
+    this.heartbeatInterval = null;
+
+    this.initTables();
+    this.loadState();
+  }
+
+  initTables() {
+    this.db.serialize(() => {
+      this.db.run(`
+        CREATE TABLE IF NOT EXISTS cvd_points (
+          symbol TEXT NOT NULL,
+          minute INTEGER NOT NULL,
+          total REAL NOT NULL,
+          bucket0 REAL NOT NULL,
+          bucket1 REAL NOT NULL,
+          bucket2 REAL NOT NULL,
+          bucket3 REAL NOT NULL,
+          bucket4 REAL NOT NULL,
+          price REAL,
+          created_at INTEGER DEFAULT (strftime('%s','now') * 1000),
+          PRIMARY KEY (symbol, minute)
+        )
+      `);
+      this.db.run('CREATE INDEX IF NOT EXISTS idx_cvd_symbol_minute ON cvd_points(symbol, minute DESC)');
+    });
+  }
+
+  loadState() {
+    this.db.get(
+      'SELECT * FROM cvd_points WHERE symbol = ? ORDER BY minute DESC LIMIT 1',
+      [this.symbol],
+      (err, row) => {
+        if (err) {
+          console.error('[CVD] Failed to load state:', err.message);
+          return;
+        }
+        if (row) {
+          this.cumulative = [row.bucket0, row.bucket1, row.bucket2, row.bucket3, row.bucket4];
+          this.cumulativeTotal = row.total;
+          this.currentMinute = row.minute;
+          this.lastPrice = row.price;
+        }
+      }
+    );
+  }
+
+  createZeroBuckets() {
+    return BUCKETS.map(() => 0);
+  }
+
+  start() {
+    if (this.ws) {
+      return;
+    }
+    this.connect();
+    if (!this.heartbeatInterval) {
+      this.heartbeatInterval = setInterval(() => {
+        this.flushIfStale();
+      }, 15_000);
+      this.heartbeatInterval.unref?.();
+    }
+  }
+
+  connect() {
+    const endpoint = `wss://stream.binance.com:9443/ws/${this.symbolLower}@trade`;
+    this.ws = new WebSocket(endpoint);
+
+    this.ws.on('open', () => {
+      this.connected = true;
+      console.log(`[CVD] Connected trade stream for ${this.symbol}`);
+    });
+
+    this.ws.on('message', (raw) => {
+      try {
+        const payload = JSON.parse(raw.toString());
+        if (!payload || payload.s !== this.symbol) {
+          return;
+        }
+        this.handleTrade(payload);
+      } catch (error) {
+        console.error('[CVD] Failed to parse trade message:', error.message);
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.connected = false;
+      this.ws = null;
+      console.warn(`[CVD] Trade stream closed for ${this.symbol}, retrying in 5s`);
+      setTimeout(() => this.connect(), 5000);
+    });
+
+    this.ws.on('error', (error) => {
+      console.error('[CVD] Trade stream error:', error.message);
+      this.ws?.close();
+    });
+  }
+
+  stop() {
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+    if (this.heartbeatInterval) {
+      clearInterval(this.heartbeatInterval);
+      this.heartbeatInterval = null;
+    }
+  }
+
+  handleTrade(trade) {
+    const price = Number(trade.p);
+    const quantity = Number(trade.q);
+    if (!Number.isFinite(price) || !Number.isFinite(quantity)) {
+      return;
+    }
+
+    const tradeTime = Number(trade.T || trade.E || Date.now());
+    const minute = Math.floor(tradeTime / 60000) * 60000;
+    const notional = price * quantity;
+    const direction = trade.m ? -1 : 1; // market buy -> m false
+
+    if (this.currentMinute === null) {
+      this.currentMinute = minute;
+    }
+
+    if (minute > this.currentMinute) {
+      this.flushPending();
+
+      while (minute - this.currentMinute > 60000) {
+        this.currentMinute += 60000;
+        this.pending = this.createZeroBuckets();
+        this.pendingTotal = 0;
+        this.flushPending();
+      }
+
+      this.currentMinute = minute;
+      this.pending = this.createZeroBuckets();
+      this.pendingTotal = 0;
+    }
+
+    const bucketIndex = this.getBucketIndex(notional);
+    if (bucketIndex === -1) {
+      return;
+    }
+
+    this.pending[bucketIndex] += direction * notional;
+    this.pendingTotal += direction * notional;
+    this.lastPrice = price;
+    this.lastTimestamp = tradeTime;
+  }
+
+  getBucketIndex(notional) {
+    for (let i = 0; i < BUCKETS.length; i += 1) {
+      const bucket = BUCKETS[i];
+      if (notional >= bucket.min && notional < bucket.max) {
+        return i;
+      }
+    }
+    return BUCKETS.length - 1;
+  }
+
+  flushPending() {
+    if (this.currentMinute === null) {
+      return;
+    }
+
+    const nextCumulative = this.cumulative.map((value, idx) => value + this.pending[idx]);
+    const nextTotal = this.cumulativeTotal + this.pendingTotal;
+
+    const row = {
+      symbol: this.symbol,
+      minute: this.currentMinute,
+      total: nextTotal,
+      buckets: nextCumulative,
+      price: this.lastPrice,
+    };
+
+    this.cumulative = nextCumulative;
+    this.cumulativeTotal = nextTotal;
+    this.pending = this.createZeroBuckets();
+    this.pendingTotal = 0;
+
+    this.persistRow(row);
+    this.emit('minute', row);
+  }
+
+  flushIfStale() {
+    if (this.currentMinute === null) {
+      return;
+    }
+
+    const currentMinute = Math.floor(Date.now() / 60000) * 60000;
+    if (currentMinute > this.currentMinute) {
+      this.flushPending();
+
+      while (currentMinute - this.currentMinute > 60000) {
+        this.currentMinute += 60000;
+        this.pending = this.createZeroBuckets();
+        this.pendingTotal = 0;
+        this.flushPending();
+      }
+
+      this.currentMinute = currentMinute;
+      this.pending = this.createZeroBuckets();
+      this.pendingTotal = 0;
+    }
+  }
+
+  persistRow(row) {
+    this.db.run(
+      `INSERT OR REPLACE INTO cvd_points
+        (symbol, minute, total, bucket0, bucket1, bucket2, bucket3, bucket4, price)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+      ,
+      [
+        row.symbol,
+        row.minute,
+        row.total,
+        row.buckets[0],
+        row.buckets[1],
+        row.buckets[2],
+        row.buckets[3],
+        row.buckets[4],
+        row.price,
+      ],
+      (err) => {
+        if (err) {
+          console.error('[CVD] Failed to store minute snapshot:', err.message);
+        }
+      }
+    );
+  }
+
+  getHistory({ limit = 1440 } = {}) {
+    return new Promise((resolve, reject) => {
+      this.db.all(
+        `SELECT minute, total, bucket0, bucket1, bucket2, bucket3, bucket4, price
+         FROM cvd_points
+         WHERE symbol = ?
+         ORDER BY minute DESC
+         LIMIT ?`,
+        [this.symbol, limit],
+        (err, rows) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(rows.reverse());
+        }
+      );
+    });
+  }
+
+  getPriceHistory({ limit = 1440 } = {}) {
+    return new Promise((resolve, reject) => {
+      this.db.all(
+        `SELECT minute, price
+         FROM cvd_points
+         WHERE symbol = ? AND price IS NOT NULL
+         ORDER BY minute DESC
+         LIMIT ?`,
+        [this.symbol, limit],
+        (err, rows) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(rows.reverse());
+        }
+      );
+    });
+  }
+}
+
+module.exports = {
+  CVDEngine,
+  BUCKETS,
+};

--- a/server/engines/heatmapEngine.js
+++ b/server/engines/heatmapEngine.js
@@ -1,0 +1,250 @@
+const EventEmitter = require('events');
+const WebSocket = require('ws');
+const fetch = require('node-fetch');
+
+class HeatmapEngine extends EventEmitter {
+  constructor({ db, symbol }) {
+    super();
+    this.db = db;
+    this.symbol = symbol.toUpperCase();
+    this.symbolLower = this.symbol.toLowerCase();
+
+    this.ws = null;
+    this.connected = false;
+
+    this.bids = new Map();
+    this.asks = new Map();
+    this.lastUpdateId = null;
+    this.snapshotReady = false;
+    this.snapshotTimer = null;
+    this.lastPrice = null;
+
+    this.initTable();
+  }
+
+  initTable() {
+    this.db.serialize(() => {
+      this.db.run(`
+        CREATE TABLE IF NOT EXISTS orderbook_snapshots (
+          symbol TEXT NOT NULL,
+          timestamp INTEGER NOT NULL,
+          bids TEXT NOT NULL,
+          asks TEXT NOT NULL,
+          last_price REAL,
+          PRIMARY KEY (symbol, timestamp)
+        )
+      `);
+      this.db.run('CREATE INDEX IF NOT EXISTS idx_snapshots_symbol_time ON orderbook_snapshots(symbol, timestamp DESC)');
+    });
+  }
+
+  start() {
+    this.fetchInitialSnapshot()
+      .then(() => {
+        this.openSocket();
+        this.startSnapshotTimer();
+      })
+      .catch((error) => {
+        console.error('[HEATMAP] Failed to load initial snapshot:', error.message);
+        setTimeout(() => this.start(), 5000);
+      });
+  }
+
+  stop() {
+    if (this.ws) {
+      this.ws.removeAllListeners();
+      this.ws.close();
+      this.ws = null;
+    }
+    if (this.snapshotTimer) {
+      clearInterval(this.snapshotTimer);
+      this.snapshotTimer = null;
+    }
+  }
+
+  async fetchInitialSnapshot() {
+    const url = `https://api.binance.com/api/v3/depth?symbol=${this.symbol}&limit=1000`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Snapshot request failed: ${response.status}`);
+    }
+    const payload = await response.json();
+    this.lastUpdateId = payload.lastUpdateId;
+    this.bids = new Map(payload.bids.map(([price, qty]) => [Number(price), Number(qty)]));
+    this.asks = new Map(payload.asks.map(([price, qty]) => [Number(price), Number(qty)]));
+    this.snapshotReady = true;
+  }
+
+  openSocket() {
+    const endpoint = `wss://stream.binance.com:9443/ws/${this.symbolLower}@depth@100ms`;
+    this.ws = new WebSocket(endpoint);
+
+    this.ws.on('open', () => {
+      this.connected = true;
+      console.log(`[HEATMAP] Connected depth stream for ${this.symbol}`);
+    });
+
+    this.ws.on('message', (raw) => {
+      try {
+        const payload = JSON.parse(raw.toString());
+        this.handleDepth(payload);
+      } catch (error) {
+        console.error('[HEATMAP] Failed to parse depth update:', error.message);
+      }
+    });
+
+    this.ws.on('close', () => {
+      this.connected = false;
+      this.ws = null;
+      console.warn(`[HEATMAP] Depth stream closed for ${this.symbol}, retrying in 5s`);
+      setTimeout(() => this.openSocket(), 5000);
+    });
+
+    this.ws.on('error', (error) => {
+      console.error('[HEATMAP] Depth stream error:', error.message);
+      this.ws?.close();
+    });
+  }
+
+  handleDepth(update) {
+    if (!this.snapshotReady) {
+      return;
+    }
+    if (typeof update.u !== 'number' || typeof update.U !== 'number') {
+      return;
+    }
+
+    if (this.lastUpdateId && update.u <= this.lastUpdateId) {
+      return;
+    }
+
+    if (update.U > this.lastUpdateId + 1) {
+      // Missed updates; reset
+      console.warn('[HEATMAP] Missed depth updates, reloading snapshot');
+      this.snapshotReady = false;
+      this.stop();
+      this.start();
+      return;
+    }
+
+    this.lastUpdateId = update.u;
+
+    if (Array.isArray(update.b)) {
+      update.b.forEach(([price, qty]) => {
+        this.applyLevel(this.bids, price, qty, true);
+      });
+    }
+    if (Array.isArray(update.a)) {
+      update.a.forEach(([price, qty]) => {
+        this.applyLevel(this.asks, price, qty, false);
+      });
+    }
+
+    const bestBid = this.bids.size ? Math.max(...this.bids.keys()) : null;
+    const bestAsk = this.asks.size ? Math.min(...this.asks.keys()) : null;
+    if (bestBid && bestAsk) {
+      this.lastPrice = (bestBid + bestAsk) / 2;
+    }
+  }
+
+  applyLevel(book, priceStr, qtyStr, isBid) {
+    const price = Number(priceStr);
+    const qty = Number(qtyStr);
+    if (!Number.isFinite(price) || !Number.isFinite(qty)) {
+      return;
+    }
+    if (qty <= 0) {
+      book.delete(price);
+    } else {
+      book.set(price, qty);
+    }
+
+    // Prune to keep maps manageable
+    const MAX_LEVELS = 500;
+    if (book.size > MAX_LEVELS) {
+      const sorted = Array.from(book.keys()).sort((a, b) => (isBid ? b - a : a - b));
+      const slice = sorted.slice(0, MAX_LEVELS);
+      const trimmed = new Map();
+      slice.forEach((key) => {
+        trimmed.set(key, book.get(key) || 0);
+      });
+      book.clear();
+      trimmed.forEach((value, key) => {
+        book.set(key, value);
+      });
+    }
+  }
+
+  startSnapshotTimer() {
+    if (this.snapshotTimer) {
+      clearInterval(this.snapshotTimer);
+    }
+    this.captureSnapshot();
+    this.snapshotTimer = setInterval(() => {
+      this.captureSnapshot();
+    }, 30_000);
+    this.snapshotTimer.unref?.();
+  }
+
+  captureSnapshot() {
+    if (!this.snapshotReady) {
+      return;
+    }
+    const timestamp = Date.now();
+    const bids = this.serializeBook(this.bids, true);
+    const asks = this.serializeBook(this.asks, false);
+
+    this.db.run(
+      `INSERT OR REPLACE INTO orderbook_snapshots (symbol, timestamp, bids, asks, last_price)
+       VALUES (?, ?, ?, ?, ?)` ,
+      [this.symbol, timestamp, JSON.stringify(bids), JSON.stringify(asks), this.lastPrice],
+      (err) => {
+        if (err) {
+          console.error('[HEATMAP] Failed to store snapshot:', err.message);
+        }
+      }
+    );
+
+    const retentionCutoff = timestamp - 48 * 60 * 60 * 1000;
+    this.db.run(
+      'DELETE FROM orderbook_snapshots WHERE symbol = ? AND timestamp < ?',
+      [this.symbol, retentionCutoff],
+      (err) => {
+        if (err) {
+          console.error('[HEATMAP] Failed to prune snapshots:', err.message);
+        }
+      }
+    );
+
+    this.emit('snapshot', { symbol: this.symbol, timestamp, bids, asks, lastPrice: this.lastPrice });
+  }
+
+  serializeBook(book, isBid) {
+    const sorted = Array.from(book.entries()).sort((a, b) => (isBid ? b[0] - a[0] : a[0] - b[0]));
+    return sorted.slice(0, 400);
+  }
+
+  getSnapshots({ limit = 720 } = {}) {
+    return new Promise((resolve, reject) => {
+      this.db.all(
+        `SELECT timestamp, bids, asks, last_price
+         FROM orderbook_snapshots
+         WHERE symbol = ?
+         ORDER BY timestamp DESC
+         LIMIT ?`,
+        [this.symbol, limit],
+        (err, rows) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(rows.reverse());
+        }
+      );
+    });
+  }
+}
+
+module.exports = {
+  HeatmapEngine,
+};


### PR DESCRIPTION
## Summary
- add SQLite-backed market data engines for Binance trade CVD and orderbook heatmap streams
- expose REST APIs for cumulative delta, liquidity heatmap, and price history consumption
- deliver a neon cosmic-themed dashboard page with synchronized ECharts heatmap and CVD lines, and link it from Cosmos menu

## Testing
- ⚠️ `npm install` *(fails: 403 Forbidden when downloading sqlite3 from npm registry)*
- ✅ `node --check server/engines/cvdEngine.js`
- ✅ `node --check server/engines/heatmapEngine.js`
- ✅ `node --check server/api/cvd.js`
- ✅ `node --check server/api/heatmap.js`
- ✅ `node --check server/api/price.js`
- ✅ `node --check apps/web/menu/cosmos/cvd-heatmap.js`


------
https://chatgpt.com/codex/tasks/task_e_68da34b3e950832f8af760063e7a9439