### PR TITLE
Add Seed AI cosmic weather report section and API

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -33,6 +33,7 @@
   </script>
 
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&family=Space+Grotesk:wght@300;400;500;600;700&family=Orbitron:wght@400;700;900&display=swap" rel="stylesheet"/>
+  <link rel="stylesheet" href="seed-weather.css"/>
 
   <style>
     #app{position:relative; z-index:2}
@@ -929,6 +930,7 @@
   <nav class="nav">
     <ul class="nav-links">
       <li><a href="/menu/cosmos/">Crypto Market</a></li>
+      <li><a href="#seed-weather">Cosmic Weather</a></li>
       <li><a href="/menu/orbits.html">Orbits</a></li>
       <li><a href="/menu/method.html">Method</a></li>
       <li><a href="/menu/psyche.html">Psyche</a></li>
@@ -1018,6 +1020,11 @@
         </div>
       </div>
 
+      <section id="seed-weather" class="section-content cosmic-section">
+        <h2 class="section-title">Two.4 — Seed AI 예측 날씨</h2>
+        <div id="seed-weather-root"></div>
+      </section>
+
       <div class="section-content">
         <h2 class="section-title">Intelligence Feed</h2>
         <div class="news-grid">
@@ -1062,8 +1069,9 @@
     <div class="menu-close" id="menuClose" aria-label="Close">×</div>
     <div class="menu-section">
       <ul class="menu-items">
-<li class="menu-item"><a href="menu/cosmos/" class="menu-link">COSMOS CRYPTO</a><span class="korean-desc">차트</span></li> 
-<li class="menu-item"><a href="menu/cosmos/" class="menu-link">CRYPTO MARKET<span class="korean-desc">암호화폐 시세</span></a></li>       
+<li class="menu-item"><a href="menu/cosmos/" class="menu-link">COSMOS CRYPTO</a><span class="korean-desc">차트</span></li>
+<li class="menu-item"><a href="#seed-weather" class="menu-link">COSMIC WEATHER<span class="korean-desc">시장 기상</span></a></li>
+<li class="menu-item"><a href="menu/cosmos/" class="menu-link">CRYPTO MARKET<span class="korean-desc">암호화폐 시세</span></a></li>
 <li class="menu-item"><a href="menu/orbits.html" class="menu-link">ORBITS (SIGNALS / INDICATORS)<span class="korean-desc">지표/신호</span></a></li>
 <li class="menu-item"><a href="menu/method.html" class="menu-link">METHOD (TECHNIQUE)<span class="korean-desc">매매 기법</span></a></li>
 <li class="menu-item"><a href="menu/psyche.html" class="menu-link">PSYCHE<span class="korean-desc">마음과 철학, 멘탈</span></a></li>
@@ -1110,7 +1118,8 @@
     
   </div>
   
-<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
+  <script src="seed-weather.js" defer></script>
   <script>
     function createSeedPlanet() {
       const canvas = document.getElementById('planet-canvas');

--- a/apps/web/seed-weather.css
+++ b/apps/web/seed-weather.css
@@ -1,0 +1,290 @@
+#seed-weather {
+  margin-top: 3rem;
+  padding: 3rem 2rem;
+  border-radius: 20px;
+  background: linear-gradient(145deg, rgba(17, 26, 47, 0.8), rgba(6, 12, 24, 0.92));
+  box-shadow:
+    0 0 60px rgba(79, 70, 229, 0.3),
+    0 0 120px rgba(14, 116, 144, 0.2);
+  border: 1px solid rgba(92, 170, 255, 0.15);
+  position: relative;
+  overflow: hidden;
+}
+
+#seed-weather::before {
+  content: '';
+  position: absolute;
+  inset: -30%;
+  background: radial-gradient(circle at 80% 20%, rgba(14, 165, 233, 0.18), transparent 55%),
+    radial-gradient(circle at 10% 90%, rgba(244, 114, 182, 0.18), transparent 55%);
+  opacity: 0.8;
+  pointer-events: none;
+}
+
+#seed-weather h2 {
+  font-family: 'Orbitron', sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2.2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #e0f2ff;
+  margin-bottom: 1.8rem;
+  position: relative;
+  z-index: 1;
+}
+
+#seed-weather-root {
+  position: relative;
+  z-index: 1;
+}
+
+.seed-weather-layout {
+  display: grid;
+  gap: 1.8rem;
+}
+
+@media (min-width: 1100px) {
+  .seed-weather-layout {
+    grid-template-columns: 1.1fr 1fr;
+    align-items: stretch;
+  }
+}
+
+.seed-weather-headline {
+  display: flex;
+  flex-direction: column;
+  gap: 1.2rem;
+}
+
+.seed-weather-grid {
+  display: grid;
+  gap: 1.2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.seed-weather-card {
+  position: relative;
+  padding: 1.6rem;
+  border-radius: 18px;
+  border: 1px solid rgba(128, 200, 255, 0.18);
+  background: linear-gradient(155deg, rgba(16, 24, 40, 0.92), rgba(10, 17, 32, 0.82));
+  backdrop-filter: blur(14px);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 233, 255, 0.1),
+    0 20px 35px rgba(12, 18, 36, 0.65);
+  transition: transform 0.4s ease, box-shadow 0.4s ease, border-color 0.4s ease;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+}
+
+.seed-weather-card[data-action='push'] {
+  border-color: rgba(129, 230, 217, 0.35);
+  box-shadow:
+    inset 0 0 0 1px rgba(56, 189, 248, 0.22),
+    0 20px 38px rgba(14, 116, 144, 0.55);
+}
+
+.seed-weather-card[data-action='protect'] {
+  border-color: rgba(251, 146, 60, 0.35);
+  box-shadow:
+    inset 0 0 0 1px rgba(251, 191, 36, 0.18),
+    0 20px 38px rgba(180, 83, 9, 0.45);
+}
+
+.seed-weather-card::after {
+  content: '';
+  position: absolute;
+  inset: 1px;
+  border-radius: 16px;
+  background: linear-gradient(145deg, rgba(46, 91, 255, 0.16), transparent 68%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  pointer-events: none;
+}
+
+.seed-weather-card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(138, 208, 255, 0.4);
+  box-shadow:
+    inset 0 0 0 1px rgba(148, 233, 255, 0.24),
+    0 28px 44px rgba(12, 18, 36, 0.75);
+}
+
+.seed-weather-card:hover::after {
+  opacity: 1;
+}
+
+.seed-weather-card-header {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.seed-weather-icon {
+  --glow-color: rgba(96, 165, 250, 0.55);
+  width: 64px;
+  height: 64px;
+  border-radius: 22px;
+  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.25), transparent 65%),
+    linear-gradient(145deg, rgba(53, 98, 207, 0.9), rgba(16, 24, 45, 0.9));
+  display: grid;
+  place-items: center;
+  font-size: 1.9rem;
+  box-shadow: 0 0 18px var(--glow-color), inset 0 0 22px rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(170, 220, 255, 0.22);
+}
+
+.seed-weather-icon[data-sky='sunny'],
+.seed-weather-icon[data-sky='clear'] {
+  --glow-color: rgba(252, 211, 77, 0.6);
+  background: radial-gradient(circle at 30% 30%, rgba(255, 248, 193, 0.35), transparent 65%),
+    linear-gradient(145deg, rgba(251, 191, 36, 0.92), rgba(22, 22, 36, 0.9));
+}
+
+.seed-weather-icon[data-sky='breeze'] {
+  --glow-color: rgba(96, 165, 250, 0.55);
+  background: radial-gradient(circle at 30% 30%, rgba(222, 239, 255, 0.35), transparent 65%),
+    linear-gradient(145deg, rgba(59, 130, 246, 0.88), rgba(15, 23, 42, 0.9));
+}
+
+.seed-weather-icon[data-sky='overcast'] {
+  --glow-color: rgba(148, 163, 184, 0.5);
+  background: radial-gradient(circle at 30% 30%, rgba(226, 232, 240, 0.3), transparent 65%),
+    linear-gradient(145deg, rgba(71, 85, 105, 0.9), rgba(15, 23, 42, 0.9));
+}
+
+.seed-weather-icon[data-sky='storm'] {
+  --glow-color: rgba(129, 140, 248, 0.65);
+  background: radial-gradient(circle at 30% 30%, rgba(199, 210, 254, 0.3), transparent 65%),
+    linear-gradient(145deg, rgba(99, 102, 241, 0.92), rgba(12, 21, 42, 0.9));
+}
+
+.seed-weather-icon[data-sky='typhoon'] {
+  --glow-color: rgba(244, 114, 182, 0.65);
+  background: radial-gradient(circle at 30% 30%, rgba(248, 191, 235, 0.4), transparent 65%),
+    linear-gradient(145deg, rgba(236, 72, 153, 0.92), rgba(16, 13, 41, 0.9));
+}
+
+.seed-weather-card-title {
+  font-family: 'Space Grotesk', sans-serif;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  font-size: 1rem;
+  text-transform: uppercase;
+  color: rgba(224, 242, 255, 0.95);
+}
+
+.seed-weather-updated {
+  font-size: 0.82rem;
+  color: rgba(191, 219, 254, 0.6);
+  letter-spacing: 0.04em;
+}
+
+.seed-weather-forecast {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  color: rgba(235, 245, 255, 0.92);
+  font-family: 'Inter', sans-serif;
+}
+
+.seed-weather-action {
+  font-size: 0.92rem;
+  font-weight: 600;
+  color: rgba(129, 230, 217, 0.92);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.seed-weather-metrics {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+}
+
+.seed-weather-metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.seed-weather-metric span {
+  font-size: 0.74rem;
+  letter-spacing: 0.14em;
+  color: rgba(148, 163, 184, 0.75);
+  text-transform: uppercase;
+}
+
+.seed-weather-metric strong {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.95);
+}
+
+.seed-weather-toast {
+  position: fixed;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: linear-gradient(120deg, rgba(30, 58, 138, 0.92), rgba(14, 116, 144, 0.92));
+  color: #e0f2ff;
+  padding: 0.85rem 1.6rem;
+  border-radius: 999px;
+  border: 1px solid rgba(190, 242, 255, 0.3);
+  box-shadow: 0 20px 40px rgba(14, 116, 144, 0.45);
+  font-size: 0.95rem;
+  z-index: 2000;
+  opacity: 0;
+  animation: seedToastFade 4.5s ease forwards;
+}
+
+@keyframes seedToastFade {
+  0% { opacity: 0; transform: translate(-50%, -15px); }
+  8% { opacity: 1; transform: translate(-50%, 0); }
+  85% { opacity: 1; transform: translate(-50%, 0); }
+  100% { opacity: 0; transform: translate(-50%, -15px); }
+}
+
+.seed-weather-skeleton {
+  position: relative;
+  overflow: hidden;
+}
+
+.seed-weather-skeleton::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(120deg, transparent, rgba(148, 197, 255, 0.12), transparent);
+  transform: translateX(-100%);
+  animation: seedSkeleton 1.8s linear infinite;
+}
+
+@keyframes seedSkeleton {
+  0% { transform: translateX(-100%); }
+  60% { transform: translateX(100%); }
+  100% { transform: translateX(100%); }
+}
+
+.seed-weather-empty {
+  text-align: center;
+  padding: 2rem;
+  color: rgba(148, 163, 184, 0.85);
+  font-size: 0.95rem;
+}
+
+@media (max-width: 768px) {
+  #seed-weather {
+    margin: 2rem 0 0;
+    padding: 2.2rem 1.5rem;
+  }
+
+  .seed-weather-icon {
+    width: 54px;
+    height: 54px;
+    font-size: 1.5rem;
+    border-radius: 18px;
+  }
+
+  .seed-weather-card {
+    padding: 1.3rem;
+  }
+}

--- a/apps/web/seed-weather.js
+++ b/apps/web/seed-weather.js
@@ -1,0 +1,235 @@
+(() => {
+  const REFRESH_INTERVAL = 5 * 60 * 1000;
+  const ENDPOINT = '/api/seed-weather?symbol=BTCUSDT';
+
+  const SKY_ICONS = {
+    sunny: '☀️',
+    clear: '🌤️',
+    breeze: '🌬️',
+    overcast: '☁️',
+    storm: '⛈️',
+    typhoon: '🌀',
+  };
+
+  const SKY_LABELS = {
+    sunny: '쾌청',
+    clear: '맑음',
+    breeze: '산들',
+    overcast: '흐림',
+    storm: '폭풍',
+    typhoon: '태풍',
+  };
+
+  const VOL_LABELS = {
+    low: '낮음',
+    normal: '보통',
+    high: '높음',
+    extreme: '극단',
+  };
+
+  const TREND_LABELS = {
+    up: '상승',
+    flat: '중립',
+    down: '하락',
+  };
+
+  const CVD_LABELS = {
+    whale_push: '고래 매수',
+    whale_dump: '고래 매도',
+    retail_push: '개미 매수',
+    mixed: '혼조',
+    neutral: '중립',
+  };
+
+  const root = document.getElementById('seed-weather-root');
+  if (!root) return;
+
+  let refreshTimer = null;
+  let controller = null;
+  let hasRendered = false;
+  let lastData = null;
+
+  function getSkyIcon(sky) {
+    return SKY_ICONS[sky] || '✨';
+  }
+
+  function formatTime(timestamp) {
+    if (!timestamp) return '';
+    try {
+      const date = new Date(timestamp);
+      return `${date.getHours().toString().padStart(2, '0')}:${date.getMinutes().toString().padStart(2, '0')} 업데이트`;
+    } catch (_) {
+      return '';
+    }
+  }
+
+  function formatBreadth(value) {
+    if (typeof value !== 'number') return '—';
+    return `${Math.round(value * 100)}%`;
+  }
+
+  function metric(label, value) {
+    return `
+      <div class="seed-weather-metric">
+        <span>${label}</span>
+        <strong>${value}</strong>
+      </div>
+    `;
+  }
+
+  function renderHeadline(data, symbol, asOf) {
+    const forecast = data.forecast || {};
+    return `
+      <article class="seed-weather-card seed-weather-headline" data-action="${forecast.actionKey || ''}">
+        <header class="seed-weather-card-header">
+          <div class="seed-weather-icon" data-sky="${data.sky}">${getSkyIcon(data.sky)}</div>
+          <div>
+            <div class="seed-weather-card-title">${symbol} 헤드라인</div>
+            <div class="seed-weather-updated">${formatTime(asOf)}</div>
+          </div>
+        </header>
+        <div class="seed-weather-forecast">${forecast.narrative || '데이터를 기다리는 중입니다.'}</div>
+        <div class="seed-weather-action">${forecast.action || ''}</div>
+        <div class="seed-weather-metrics">
+          ${metric('Sky', SKY_LABELS[data.sky] || data.sky || '—')}
+          ${metric('Breadth', formatBreadth(data.breadth))}
+          ${metric('Volatility', VOL_LABELS[data.volatility] || data.volatility || '—')}
+          ${metric('Trend', TREND_LABELS[data.trend4h] || data.trend4h || '—')}
+          ${metric('CVD', CVD_LABELS[data.cvdSignal] || data.cvdSignal || '—')}
+        </div>
+      </article>
+    `;
+  }
+
+  function renderSectorCard(sector) {
+    const forecast = sector.forecast || {};
+    return `
+      <article class="seed-weather-card" data-action="${forecast.actionKey || ''}">
+        <header class="seed-weather-card-header">
+          <div class="seed-weather-icon" data-sky="${sector.sky}">${getSkyIcon(sector.sky)}</div>
+          <div>
+            <div class="seed-weather-card-title">${sector.name}</div>
+            <div class="seed-weather-updated">Sky ${SKY_LABELS[sector.sky] || sector.sky || '—'}</div>
+          </div>
+        </header>
+        <div class="seed-weather-forecast">${forecast.narrative || '관측 중...'}</div>
+        <div class="seed-weather-action">${forecast.action || ''}</div>
+        <div class="seed-weather-metrics">
+          ${metric('Breadth', formatBreadth(sector.breadth))}
+          ${metric('Volatility', VOL_LABELS[sector.volatility] || sector.volatility || '—')}
+          ${metric('Trend', TREND_LABELS[sector.trend4h] || sector.trend4h || '—')}
+          ${metric('CVD', CVD_LABELS[sector.cvdSignal] || sector.cvdSignal || '—')}
+        </div>
+      </article>
+    `;
+  }
+
+  function renderWeather(data) {
+    if (!data) {
+      root.innerHTML = '<div class="seed-weather-empty">기상 데이터를 불러오지 못했습니다.</div>';
+      hasRendered = true;
+      lastData = null;
+      return;
+    }
+
+    const sectors = Array.isArray(data.sectors) ? data.sectors : [];
+
+    root.innerHTML = `
+      <div class="seed-weather-layout">
+        ${renderHeadline(data.headline || {}, data.symbol || 'BTCUSDT', data.asOf)}
+        <div class="seed-weather-grid">
+          ${sectors.map(renderSectorCard).join('')}
+        </div>
+      </div>
+    `;
+
+    hasRendered = true;
+    lastData = data;
+  }
+
+  function renderSkeleton() {
+    const skeletonCard = `
+      <article class="seed-weather-card seed-weather-skeleton">
+        <div style="height:64px"></div>
+        <div style="height:48px"></div>
+        <div style="height:88px"></div>
+      </article>
+    `;
+
+    root.innerHTML = `
+      <div class="seed-weather-layout">
+        <article class="seed-weather-card seed-weather-headline seed-weather-skeleton">
+          <div style="height:64px"></div>
+          <div style="height:60px"></div>
+          <div style="height:100px"></div>
+        </article>
+        <div class="seed-weather-grid">
+          ${Array.from({ length: 5 }).map(() => skeletonCard).join('')}
+        </div>
+      </div>
+    `;
+  }
+
+  function showToast(message) {
+    if (!message) return;
+    const toast = document.createElement('div');
+    toast.className = 'seed-weather-toast';
+    toast.textContent = message;
+    document.body.appendChild(toast);
+    setTimeout(() => {
+      toast.remove();
+    }, 4600);
+  }
+
+  function scheduleNext() {
+    if (refreshTimer) {
+      clearTimeout(refreshTimer);
+    }
+    refreshTimer = setTimeout(() => {
+      loadWeather();
+    }, REFRESH_INTERVAL);
+  }
+
+  async function loadWeather() {
+    if (!root) return;
+
+    if (!hasRendered) {
+      renderSkeleton();
+    }
+
+    if (controller) {
+      controller.abort();
+    }
+    controller = new AbortController();
+
+    try {
+      const response = await fetch(ENDPOINT, {
+        cache: 'no-store',
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      renderWeather(data);
+    } catch (error) {
+      console.error('[SeedWeather] Failed to load:', error);
+      if (lastData) {
+        showToast('Seed AI 날씨 갱신이 지연 중입니다. 마지막 데이터를 유지합니다.');
+      } else {
+        renderWeather(null);
+        showToast('Seed AI 날씨를 불러오지 못했어요. 잠시 후 다시 시도합니다.');
+      }
+    } finally {
+      scheduleNext();
+    }
+  }
+
+  document.addEventListener('visibilitychange', () => {
+    if (document.visibilityState === 'visible') {
+      loadWeather();
+    }
+  });
+
+  loadWeather();
+})();

--- a/server.js
+++ b/server.js
@@ -12,6 +12,7 @@ const { HeatmapEngine } = require('./server/engines/heatmapEngine');
 const createCvdRouter = require('./server/api/cvd');
 const createHeatmapRouter = require('./server/api/heatmap');
 const createPriceRouter = require('./server/api/price');
+const createSeedWeatherRouter = require('./server/api/seed-weather');
 
 const app = express();
 const PORT = process.env.COSMOS_PORT || process.env.PORT || 3000;
@@ -26,6 +27,7 @@ heatmapEngine.start();
 const cvdRouter = createCvdRouter({ cvdEngine });
 const heatmapRouter = createHeatmapRouter({ heatmapEngine });
 const priceRouter = createPriceRouter({ cvdEngine });
+const seedWeatherRouter = createSeedWeatherRouter();
 
 // ==============================
 // 정적 파일 서빙
@@ -333,6 +335,7 @@ orbitsRouter.delete('/posts/:id', (req, res) => {
 app.use('/api/cvd', cvdRouter);
 app.use('/api/heatmap', heatmapRouter);
 app.use('/api/price', priceRouter);
+app.use('/api/seed-weather', seedWeatherRouter);
 app.use('/api/orbits', orbitsRouter);
 app.use('/api/method', orbitsRouter);
 

--- a/server/ai/forecaster.js
+++ b/server/ai/forecaster.js
@@ -1,0 +1,117 @@
+const ACTION_TEMPLATES = {
+  push: 'Action: Push(가볍게) — 돌파 흐름을 살피세요.',
+  balance: 'Action: Balance — 호흡을 맞추고 과열만 피하세요.',
+  protect: 'Action: Protect — 방어선과 리스크 관리를 우선하세요.',
+};
+
+const SKY_DESCRIPTIONS = {
+  sunny: '햇살이 선명합니다.',
+  clear: '하늘이 개었어요.',
+  breeze: '산들바람이 불며 기류가 부드럽습니다.',
+  overcast: '구름이 낮게 깔렸습니다.',
+  storm: '폭풍구름이 몰려옵니다.',
+  typhoon: '태풍 경보급 구름이 감돌아요.',
+};
+
+const TREND_DESCRIPTIONS = {
+  up: '바람은 상단으로 불어요. 돌파 시도 신호입니다.',
+  flat: '기압은 균형을 잡으며 관망 흐름입니다.',
+  down: '하강 기류가 강하게 내려옵니다. 보호 우선이에요.',
+};
+
+const VOLATILITY_DESCRIPTIONS = {
+  low: '변동성은 잔잔한 편.',
+  normal: '파도는 보통 수준.',
+  high: '출렁임이 큰 편입니다.',
+  extreme: '번개 주의보, 파도가 큽니다.',
+};
+
+const CVD_DESCRIPTIONS = {
+  whale_push: '고래가 밀어올립니다.',
+  whale_dump: '고래가 물량을 털고 있어요.',
+  retail_push: '개미 열기가 의외로 뜨겁습니다.',
+  mixed: '매수·매도 힘이 뒤섞여요.',
+  neutral: '수급은 아직 조용합니다.',
+};
+
+function describeBreadth(breadth) {
+  if (typeof breadth !== 'number' || Number.isNaN(breadth)) return '';
+  const pct = Math.round(breadth * 100);
+  if (pct >= 70) return `참여도는 ${pct}%로 넓게 펼쳐집니다.`;
+  if (pct >= 55) return `참여도는 ${pct}% 정도, 무게 중심이 안정적입니다.`;
+  if (pct >= 40) return `참여도는 ${pct}% 수준, 중립권에서 줄다리기 중입니다.`;
+  return `참여도는 ${pct}%로 얇습니다. 민첩하게 대응하세요.`;
+}
+
+function pickAction({ action, trend4h, volatility, cvdSignal }) {
+  if (action && ACTION_TEMPLATES[action]) {
+    return action;
+  }
+
+  if (trend4h === 'down' || volatility === 'extreme' || cvdSignal === 'whale_dump') {
+    return 'protect';
+  }
+  if (trend4h === 'up' && (cvdSignal === 'whale_push' || cvdSignal === 'retail_push')) {
+    return 'push';
+  }
+  return 'balance';
+}
+
+function buildNarrative(payload, { includeBreadth = true } = {}) {
+  if (!payload || typeof payload !== 'object') return '';
+  const { sky, breadth, volatility, trend4h, cvdSignal } = payload;
+
+  const sentences = [];
+  if (sky && SKY_DESCRIPTIONS[sky]) {
+    sentences.push(SKY_DESCRIPTIONS[sky]);
+  }
+
+  if (volatility && VOLATILITY_DESCRIPTIONS[volatility]) {
+    sentences.push(VOLATILITY_DESCRIPTIONS[volatility]);
+  }
+
+  if (trend4h && TREND_DESCRIPTIONS[trend4h]) {
+    sentences.push(TREND_DESCRIPTIONS[trend4h]);
+  }
+
+  if (cvdSignal && CVD_DESCRIPTIONS[cvdSignal]) {
+    sentences.push(CVD_DESCRIPTIONS[cvdSignal]);
+  }
+
+  if (includeBreadth) {
+    const breadthLine = describeBreadth(breadth);
+    if (breadthLine) sentences.push(breadthLine);
+  }
+
+  const deduped = sentences.filter(Boolean);
+  if (!deduped.length) return '';
+
+  if (deduped.length === 1) return deduped[0];
+  return `${deduped[0]} ${deduped.slice(1).join(' ')}`;
+}
+
+function createForecast(payload, options = {}) {
+  const narrative = buildNarrative(payload, options).trim();
+  const selectedAction = pickAction(payload);
+  const actionLine = ACTION_TEMPLATES[selectedAction] || ACTION_TEMPLATES.balance;
+
+  return {
+    narrative,
+    action: actionLine,
+    actionKey: selectedAction,
+    combined: narrative ? `${narrative} ${actionLine}`.trim() : actionLine,
+  };
+}
+
+function createHeadlineText(payload) {
+  return createForecast(payload, { includeBreadth: true });
+}
+
+function createSectorText(payload) {
+  return createForecast(payload, { includeBreadth: true });
+}
+
+module.exports = {
+  createHeadlineText,
+  createSectorText,
+};

--- a/server/ai/llm.js
+++ b/server/ai/llm.js
@@ -1,0 +1,63 @@
+const fetch = require('node-fetch');
+
+const USE_LLM = String(process.env.USE_LLM || '').toLowerCase() === 'true';
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY || '';
+
+function isEnabled() {
+  return USE_LLM && OPENAI_API_KEY;
+}
+
+async function rewriteForecast({ narrative, context = {} }) {
+  if (!isEnabled()) {
+    return null;
+  }
+
+  const cleanNarrative = String(narrative || '').trim();
+  if (!cleanNarrative) {
+    return null;
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${OPENAI_API_KEY}`,
+      },
+      body: JSON.stringify({
+        model: process.env.OPENAI_MODEL || 'gpt-4o-mini',
+        temperature: 0.7,
+        max_tokens: 180,
+        messages: [
+          {
+            role: 'system',
+            content: '너는 암호화폐 시장을 기상 비유로 전달하는 한국어 캐스터야. 주어진 문장을 자연스럽고 유머러스하게 다듬되 과장하지 말고 두 문장 이내로 유지해.',
+          },
+          {
+            role: 'user',
+            content: `기본 멘트: ${cleanNarrative}\n맥락: ${JSON.stringify(context)}`,
+          },
+        ],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.warn('[LLM] rewrite failed:', response.status, errorText);
+      return null;
+    }
+
+    const data = await response.json();
+    const text = data?.choices?.[0]?.message?.content?.trim();
+    if (!text) return null;
+    return text.split('\n').map(line => line.trim()).join(' ');
+  } catch (error) {
+    console.warn('[LLM] rewrite error:', error.message);
+    return null;
+  }
+}
+
+module.exports = {
+  rewriteForecast,
+  isEnabled,
+};

--- a/server/api/seed-weather.js
+++ b/server/api/seed-weather.js
@@ -1,0 +1,207 @@
+const express = require('express');
+const { createHeadlineText, createSectorText } = require('../ai/forecaster');
+const { rewriteForecast, isEnabled } = require('../ai/llm');
+
+const FIVE_MINUTES = 5 * 60 * 1000;
+const DEFAULT_SYMBOL = 'BTCUSDT';
+
+const cache = new Map();
+
+function hashString(input) {
+  let h = 1779033703 ^ input.length;
+  for (let i = 0; i < input.length; i += 1) {
+    h = Math.imul(h ^ input.charCodeAt(i), 3432918353);
+    h = (h << 13) | (h >>> 19);
+  }
+  return (Math.imul(h ^ (h >>> 16), 2246822507) >>> 0) || 1;
+}
+
+function mulberry32(seed) {
+  let t = seed >>> 0;
+  return function next() {
+    t += 0x6d2b79f5;
+    let r = Math.imul(t ^ (t >>> 15), 1 | t);
+    r ^= r + Math.imul(r ^ (r >>> 7), 61 | r);
+    return ((r ^ (r >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const SKY_LEVELS = ['sunny', 'clear', 'breeze', 'overcast', 'storm', 'typhoon'];
+const VOL_LEVELS = ['low', 'normal', 'high', 'extreme'];
+const TREND_LEVELS = ['down', 'flat', 'up'];
+const CVD_LEVELS = ['neutral', 'mixed', 'retail_push', 'whale_push', 'whale_dump'];
+
+function chooseLevel(levels, value) {
+  const scaled = Math.max(0, Math.min(0.9999, value));
+  const index = Math.floor(scaled * levels.length);
+  return levels[Math.min(index, levels.length - 1)];
+}
+
+function deriveSky({ rng, trend4h, volatility }) {
+  const base = rng();
+  if (volatility === 'extreme') return base > 0.4 ? 'typhoon' : 'storm';
+  if (volatility === 'high') {
+    if (trend4h === 'down') return base > 0.4 ? 'storm' : 'overcast';
+    return base > 0.5 ? 'storm' : 'breeze';
+  }
+  if (trend4h === 'up') return base > 0.3 ? 'sunny' : 'clear';
+  if (trend4h === 'down') return base > 0.5 ? 'overcast' : 'storm';
+  return base > 0.6 ? 'breeze' : 'clear';
+}
+
+function deriveAction({ trend4h, volatility, cvdSignal }) {
+  if (trend4h === 'down' || volatility === 'extreme' || cvdSignal === 'whale_dump') {
+    return 'protect';
+  }
+  if (trend4h === 'up' && (cvdSignal === 'whale_push' || cvdSignal === 'retail_push')) {
+    return 'push';
+  }
+  return 'balance';
+}
+
+function formatNumber(value, min, max) {
+  return Math.min(max, Math.max(min, value));
+}
+
+function buildSectorPayload({ symbol, name, bucket, index }) {
+  const seed = hashString(`${symbol}:${name}:${bucket}:${index}`);
+  const rng = mulberry32(seed);
+
+  const breadth = formatNumber(0.28 + rng() * 0.6, 0.18, 0.92);
+  const volatility = chooseLevel(VOL_LEVELS, rng());
+  const trend4h = chooseLevel(TREND_LEVELS, rng());
+  const cvdSignal = chooseLevel(CVD_LEVELS, rng());
+  const action = deriveAction({ trend4h, volatility, cvdSignal });
+  const sky = deriveSky({ rng, trend4h, volatility });
+
+  return {
+    name,
+    sky,
+    breadth: Number(breadth.toFixed(2)),
+    volatility,
+    trend4h,
+    cvdSignal,
+    action,
+  };
+}
+
+function buildHeadlinePayload({ symbol, bucket }) {
+  const seed = hashString(`${symbol}:headline:${bucket}`);
+  const rng = mulberry32(seed);
+
+  const breadth = formatNumber(0.35 + rng() * 0.5, 0.2, 0.95);
+  const volatility = chooseLevel(VOL_LEVELS, rng());
+  const trend4h = chooseLevel(TREND_LEVELS, rng());
+  const cvdSignal = chooseLevel(CVD_LEVELS, rng());
+  const action = deriveAction({ trend4h, volatility, cvdSignal });
+  const sky = deriveSky({ rng, trend4h, volatility });
+
+  return {
+    sky,
+    breadth: Number(breadth.toFixed(2)),
+    volatility,
+    trend4h,
+    cvdSignal,
+    action,
+  };
+}
+
+const DEFAULT_SECTORS = [
+  'AI',
+  'RWA',
+  'Oracle · LINK',
+  'DeFi',
+  'Meme/High-Beta',
+];
+
+async function applyForecastText(payload, { type, symbol, asOf }) {
+  const ruleBased = type === 'headline'
+    ? createHeadlineText(payload)
+    : createSectorText(payload);
+
+  let narrative = ruleBased.narrative;
+
+  if (narrative && isEnabled()) {
+    const rewritten = await rewriteForecast({
+      narrative,
+      context: { type, symbol, at: asOf, name: payload.name || 'headline' },
+    });
+    if (rewritten) {
+      narrative = rewritten;
+    }
+  }
+
+  return {
+    ...payload,
+    forecast: {
+      narrative,
+      action: ruleBased.action,
+      actionKey: ruleBased.actionKey,
+      combined: narrative ? `${narrative} ${ruleBased.action}`.trim() : ruleBased.action,
+    },
+  };
+}
+
+async function generateWeather(symbol) {
+  const now = Date.now();
+  const bucket = Math.floor(now / FIVE_MINUTES);
+
+  const headlinePayload = buildHeadlinePayload({ symbol, bucket });
+  const enrichedHeadline = await applyForecastText(headlinePayload, {
+    type: 'headline',
+    symbol,
+    asOf: now,
+  });
+
+  const sectors = await Promise.all(
+    DEFAULT_SECTORS.map((name, index) => buildSectorPayload({ symbol, name, bucket, index }))
+      .map(async (payload) => applyForecastText(payload, {
+        type: 'sector',
+        symbol,
+        asOf: now,
+      })),
+  );
+
+  return {
+    asOf: now,
+    symbol,
+    headline: enrichedHeadline,
+    sectors,
+  };
+}
+
+async function getWeather(symbol) {
+  const normalizedSymbol = String(symbol || DEFAULT_SYMBOL).toUpperCase();
+  const key = normalizedSymbol;
+  const now = Date.now();
+  const existing = cache.get(key);
+
+  if (existing && existing.expires > now) {
+    return existing.data;
+  }
+
+  const data = await generateWeather(normalizedSymbol);
+  cache.set(key, {
+    data,
+    expires: now + FIVE_MINUTES,
+  });
+  return data;
+}
+
+module.exports = function createSeedWeatherRouter() {
+  const router = express.Router();
+
+  router.get('/', async (req, res) => {
+    try {
+      const symbol = String(req.query.symbol || DEFAULT_SYMBOL).toUpperCase();
+      const weather = await getWeather(symbol);
+      res.setHeader('Cache-Control', 'public, max-age=60');
+      return res.json(weather);
+    } catch (error) {
+      console.error('[API/SEED-WEATHER] Failed to build response:', error);
+      return res.status(500).json({ error: 'Failed to generate Seed AI weather data.' });
+    }
+  });
+
+  return router;
+};


### PR DESCRIPTION
## Summary
- add a rule-based forecaster with optional LLM rewrite hook for Seed AI weather copy
- expose a cached /api/seed-weather endpoint and wire it into the server routing
- build the cosmic weather section on the homepage with neon styling, auto-refresh cards, and quick navigation

## Testing
- node -e "const createRouter = require('./server/api/seed-weather'); const router = createRouter(); console.log(typeof router);"
- node -e "const { createHeadlineText } = require('./server/ai/forecaster'); console.log(createHeadlineText({sky:'sunny', breadth:0.7, volatility:'high', trend4h:'up', cvdSignal:'whale_push', action:'push'}));"

------
https://chatgpt.com/codex/tasks/task_e_68da5e14bfbc832f80a457aa97920c55