### PR TITLE
Update COSMOS chart defaults and add core flow simulation

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1005,8 +1005,9 @@
   <!-- Content - 차트 영역 -->
   <section class="content-section">
     <div class="container">
-      <div class="section-content">
+      <div class="section-content cosmos-section">
         <h2 class="section-title">COSMOS CHART</h2>
+        <p class="cosmos-summary">시총 상위 자산들의 동시 흐름을 추적하며, 코어 3종(BTC·ETH·XRP)을 기준선으로 두고 나머지 자산은 필요할 때 범례에서 토글해 비교할 수 있습니다.</p>
         <div class="chart-container">
           <div class="chart-header">
             <div class="chart-controls">
@@ -1049,6 +1050,100 @@
           <div class="coin-card" style="max-width:300px;">
             <h3 class="card-title">Oracle Q&A</h3>
             <div class="card-content">AI 오라클과 함께하는 질의응답</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="section-content core-sim-section">
+        <h2 class="section-title">Two.4 Core Flow Simulation</h2>
+        <p class="core-sim-intro">거래 인프라의 각 노드가 중앙 코어와 어떻게 연결되는지 시각화했습니다. 데이터 유입부터 전략 실행까지의 경로를 따라가며 시스템의 상호작용을 확인하세요.</p>
+        <div class="core-sim">
+          <svg class="core-sim-links" viewBox="0 0 100 100" preserveAspectRatio="none" role="presentation" aria-hidden="true">
+            <defs>
+              <linearGradient id="coreLineCool" x1="0%" y1="0%" x2="100%" y2="0%">
+                <stop offset="0%" stop-color="#38bdf8" stop-opacity="0.8"/>
+                <stop offset="100%" stop-color="#a855f7" stop-opacity="0.75"/>
+              </linearGradient>
+              <linearGradient id="coreLineWarm" x1="0%" y1="0%" x2="0%" y2="100%">
+                <stop offset="0%" stop-color="#f97316" stop-opacity="0.85"/>
+                <stop offset="100%" stop-color="#fb7185" stop-opacity="0.75"/>
+              </linearGradient>
+            </defs>
+            <path class="core-line" d="M12.5 10H37.5H62.5H87.5" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M12.5 10V90" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M12.5 30H37.5L50 50" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M12.5 50H50" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M12.5 70H37.5H50H62.5" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M12.5 90H37.5H50H62.5" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M62.5 10V70" stroke="url(#coreLineCool)"/>
+            <path class="core-line" d="M50 50H87.5" stroke="url(#coreLineWarm)"/>
+            <path class="core-line" d="M87.5 10V90" stroke="url(#coreLineWarm)"/>
+            <path class="core-line" d="M62.5 70H87.5" stroke="url(#coreLineWarm)"/>
+            <path class="core-line" d="M62.5 90H87.5" stroke="url(#coreLineWarm)"/>
+          </svg>
+          <div class="core-node node-ingress">
+            <span class="core-node-title">Ingress</span>
+            <span class="core-node-sub">Exchanges / AIs</span>
+          </div>
+          <div class="core-node node-etl">
+            <span class="core-node-title">ETL</span>
+            <span class="core-node-sub">정제 · 라우팅</span>
+          </div>
+          <div class="core-node node-storage">
+            <span class="core-node-title">Storage</span>
+            <span class="core-node-sub">장기 데이터 레이크</span>
+          </div>
+          <div class="core-node node-gpu-ingest">
+            <span class="core-node-title">GPU Cluster</span>
+            <span class="core-node-sub">실시간 파이프라인</span>
+          </div>
+          <div class="core-node node-queue-ingest">
+            <span class="core-node-title">Queue</span>
+            <span class="core-node-sub">이벤트 버퍼링</span>
+          </div>
+          <div class="core-node node-datalake">
+            <span class="core-node-title">Data Lake</span>
+            <span class="core-node-sub">시세 · 온체인 · 뉴스</span>
+          </div>
+          <div class="core-node node-orchestration">
+            <span class="core-node-title">AI Orchestration</span>
+            <span class="core-node-sub">파이프라인 스케줄링</span>
+          </div>
+          <div class="core-node node-model-serving">
+            <span class="core-node-title">Model Serving</span>
+            <span class="core-node-sub">예측 / 임베딩</span>
+          </div>
+          <div class="core-node node-strategy">
+            <span class="core-node-title">Strategy Engine</span>
+            <span class="core-node-sub">멀티모달 시그널</span>
+          </div>
+          <div class="core-node node-execution">
+            <span class="core-node-title">Execution Router</span>
+            <span class="core-node-sub">브로커 · 거래소</span>
+          </div>
+          <div class="core-node node-notify">
+            <span class="core-node-title">Notifications</span>
+            <span class="core-node-sub">경보 · 피드백</span>
+          </div>
+          <div class="core-node node-core">
+            <span class="core-node-title">Two.4 Core</span>
+            <span class="core-node-sub">시뮬레이션 · 상태 동기화</span>
+          </div>
+          <div class="core-node node-cpu">
+            <span class="core-node-title">CPU Workers</span>
+            <span class="core-node-sub">연산 · 로깅</span>
+          </div>
+          <div class="core-node node-gpu-train">
+            <span class="core-node-title">GPU Cluster</span>
+            <span class="core-node-sub">학습 · 재학습</span>
+          </div>
+          <div class="core-node node-cache">
+            <span class="core-node-title">Cache</span>
+            <span class="core-node-sub">저지연 응답</span>
+          </div>
+          <div class="core-node node-queue-out">
+            <span class="core-node-title">Queue</span>
+            <span class="core-node-sub">실행 대기열</span>
           </div>
         </div>
       </div>
@@ -1395,13 +1490,13 @@
     const cryptoConfig=[
       {id:'BTC',name:'BTC',color:'#ff9500',visible:true},
       {id:'ETH',name:'ETH',color:'#627eea',visible:true},
-      {id:'BNB',name:'BNB',color:'#f0b90b',visible:true},
-      {id:'SOL',name:'SOL',color:'#9945ff',visible:true},
-      {id:'ADA',name:'ADA',color:'#0066cc',visible:true},
+      {id:'BNB',name:'BNB',color:'#f0b90b',visible:false},
+      {id:'SOL',name:'SOL',color:'#9945ff',visible:false},
+      {id:'ADA',name:'ADA',color:'#0066cc',visible:false},
       {id:'XRP',name:'XRP',color:'#00d4aa',visible:true},
-      {id:'AVAX',name:'AVAX',color:'#e84142',visible:true},
-      {id:'DOGE',name:'DOGE',color:'#c2a633',visible:true},
-      {id:'LINK',name:'LINK',color:'#2a5ada',visible:true}
+      {id:'AVAX',name:'AVAX',color:'#e84142',visible:false},
+      {id:'DOGE',name:'DOGE',color:'#c2a633',visible:false},
+      {id:'LINK',name:'LINK',color:'#2a5ada',visible:false}
     ];
 
     const TIME_RANGES={
@@ -1506,6 +1601,7 @@
         const item=document.createElement('div');
         item.className='legend-item';
         item.innerHTML=`<div class="legend-color" style="background-color:${c.color}"></div><span>${c.name}</span>`;
+        item.style.opacity=c.visible?'1':'.35';
         item.addEventListener('click',()=>{
           c.visible=!c.visible;
           item.style.opacity=c.visible?'1':'.35';

--- a/apps/web/seed-weather.css
+++ b/apps/web/seed-weather.css
@@ -35,11 +35,46 @@
 #seed-weather-root {
   position: relative;
   z-index: 1;
+  display: block;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+}
+
+.seed-weather-frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.seed-weather-scroll {
+  position: absolute;
+  inset: 0;
+  padding: 1rem 1.25rem 1.25rem;
+  overflow-y: auto;
+  overflow-x: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.seed-weather-scroll::-webkit-scrollbar {
+  width: 6px;
+}
+
+.seed-weather-scroll::-webkit-scrollbar-thumb {
+  background: linear-gradient(180deg, rgba(56, 189, 248, 0.5), rgba(147, 197, 253, 0.3));
+  border-radius: 999px;
+}
+
+.seed-weather-scroll::-webkit-scrollbar-track {
+  background: transparent;
 }
 
 .seed-weather-layout {
   display: grid;
   gap: 1.4rem;
+  min-height: 100%;
 }
 
 @media (min-width: 1100px) {
@@ -265,6 +300,10 @@
 }
 
 .seed-weather-empty {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   text-align: center;
   padding: 2rem;
   color: rgba(148, 163, 184, 0.85);

--- a/apps/web/seed-weather.js
+++ b/apps/web/seed-weather.js
@@ -126,7 +126,13 @@
 
   function renderWeather(data) {
     if (!data) {
-      root.innerHTML = '<div class="seed-weather-empty">기상 데이터를 불러오지 못했습니다.</div>';
+      root.innerHTML = `
+        <div class="seed-weather-frame">
+          <div class="seed-weather-scroll">
+            <div class="seed-weather-empty">기상 데이터를 불러오지 못했습니다.</div>
+          </div>
+        </div>
+      `;
       hasRendered = true;
       lastData = null;
       return;
@@ -135,10 +141,14 @@
     const sectors = Array.isArray(data.sectors) ? data.sectors : [];
 
     root.innerHTML = `
-      <div class="seed-weather-layout">
-        ${renderHeadline(data.headline || {}, data.symbol || 'BTCUSDT', data.asOf)}
-        <div class="seed-weather-grid">
-          ${sectors.map(renderSectorCard).join('')}
+      <div class="seed-weather-frame">
+        <div class="seed-weather-scroll">
+          <div class="seed-weather-layout">
+            ${renderHeadline(data.headline || {}, data.symbol || 'BTCUSDT', data.asOf)}
+            <div class="seed-weather-grid">
+              ${sectors.map(renderSectorCard).join('')}
+            </div>
+          </div>
         </div>
       </div>
     `;
@@ -157,14 +167,18 @@
     `;
 
     root.innerHTML = `
-      <div class="seed-weather-layout">
-        <article class="seed-weather-card seed-weather-headline seed-weather-skeleton">
-          <div style="height:64px"></div>
-          <div style="height:60px"></div>
-          <div style="height:100px"></div>
-        </article>
-        <div class="seed-weather-grid">
-          ${Array.from({ length: 5 }).map(() => skeletonCard).join('')}
+      <div class="seed-weather-frame">
+        <div class="seed-weather-scroll">
+          <div class="seed-weather-layout">
+            <article class="seed-weather-card seed-weather-headline seed-weather-skeleton">
+              <div style="height:64px"></div>
+              <div style="height:60px"></div>
+              <div style="height:100px"></div>
+            </article>
+            <div class="seed-weather-grid">
+              ${Array.from({ length: 5 }).map(() => skeletonCard).join('')}
+            </div>
+          </div>
         </div>
       </div>
     `;

--- a/apps/web/style.css
+++ b/apps/web/style.css
@@ -136,6 +136,19 @@ section h2 {
   text-shadow: 0 0 6px var(--neon-accent2);
 }
 
+.cosmos-section .section-title {
+  margin-bottom: 0.35rem;
+}
+
+.cosmos-summary {
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(0.85rem, 1.3vw, 1rem);
+  color: rgba(224, 242, 255, 0.75);
+  letter-spacing: 0.02em;
+  margin-bottom: 0.95rem;
+  max-width: 720px;
+}
+
 /* TradingView 차트 자리 */
 .placeholder {
   height: 320px;
@@ -183,6 +196,7 @@ footer {
   .site-title { font-size: 1.6rem; }
   .tagline { font-size: 0.8rem; }
   section h2 { font-size: 1.3rem; }
+  .cosmos-summary { font-size: 0.85rem; }
 }
 
 .color-up { color:#28e07a; }
@@ -200,6 +214,182 @@ footer {
   min-height:var(--coin-icon) !important;
   border-radius:50%;
   object-fit:contain;
+}
+
+.core-sim-section {
+  position: relative;
+  overflow: hidden;
+}
+
+.core-sim-intro {
+  font-family: 'Inter', sans-serif;
+  font-size: clamp(0.9rem, 1.4vw, 1.05rem);
+  color: rgba(226, 232, 240, 0.78);
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+
+.core-sim {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(4, minmax(150px, 1fr));
+  grid-auto-rows: minmax(140px, 1fr);
+  gap: 1.4rem;
+  padding: 2rem;
+  border-radius: 24px;
+  background: radial-gradient(circle at 20% 20%, rgba(59, 130, 246, 0.14), transparent 55%),
+    radial-gradient(circle at 80% 80%, rgba(236, 72, 153, 0.12), transparent 60%),
+    rgba(12, 19, 36, 0.72);
+  box-shadow:
+    inset 0 0 0 1px rgba(96, 165, 250, 0.18),
+    0 30px 60px rgba(8, 11, 24, 0.6);
+}
+
+.core-sim-links {
+  position: absolute;
+  inset: 2rem;
+  width: calc(100% - 4rem);
+  height: calc(100% - 4rem);
+  pointer-events: none;
+}
+
+.core-line {
+  fill: none;
+  stroke-width: 4;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  opacity: 0.85;
+}
+
+.core-node {
+  position: relative;
+  border-radius: 18px;
+  padding: 1.1rem 1rem;
+  background: linear-gradient(160deg, rgba(13, 25, 48, 0.92), rgba(15, 31, 57, 0.78));
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  box-shadow:
+    0 16px 28px rgba(5, 10, 24, 0.65),
+    inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  text-align: center;
+  min-height: 120px;
+}
+
+.core-node::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: 18px;
+  background: radial-gradient(circle at 50% 0%, rgba(148, 163, 184, 0.18), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  pointer-events: none;
+}
+
+.core-node:hover::after {
+  opacity: 1;
+}
+
+.core-node-title {
+  font-family: 'Orbitron', sans-serif;
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  color: rgba(244, 244, 255, 0.92);
+  text-transform: uppercase;
+}
+
+.core-node-sub {
+  font-family: 'Inter', sans-serif;
+  font-size: 0.85rem;
+  color: rgba(191, 219, 254, 0.78);
+}
+
+.node-core {
+  grid-column: 2 / span 2;
+  grid-row: 3;
+  background: radial-gradient(circle at 50% 50%, rgba(252, 211, 77, 0.18), transparent 70%),
+    linear-gradient(160deg, rgba(31, 41, 84, 0.95), rgba(76, 29, 149, 0.85));
+  border: 1px solid rgba(255, 214, 102, 0.4);
+  box-shadow:
+    0 22px 40px rgba(15, 23, 42, 0.75),
+    inset 0 0 0 1px rgba(253, 224, 71, 0.3);
+}
+
+.node-ingress { grid-column: 1; grid-row: 1; }
+.node-etl { grid-column: 1; grid-row: 2; }
+.node-storage { grid-column: 1; grid-row: 3; }
+.node-gpu-ingest { grid-column: 1; grid-row: 4; }
+.node-queue-ingest { grid-column: 1; grid-row: 5; }
+.node-datalake { grid-column: 2; grid-row: 1; }
+.node-orchestration { grid-column: 3; grid-row: 1; }
+.node-model-serving { grid-column: 4; grid-row: 1; }
+.node-strategy { grid-column: 4; grid-row: 2; }
+.node-execution { grid-column: 4; grid-row: 4; }
+.node-notify { grid-column: 4; grid-row: 5; }
+.node-cpu { grid-column: 2; grid-row: 4; }
+.node-gpu-train { grid-column: 3; grid-row: 4; }
+.node-cache { grid-column: 2; grid-row: 5; }
+.node-queue-out { grid-column: 3; grid-row: 5; }
+
+.core-sim::before {
+  content: '';
+  position: absolute;
+  inset: 2rem;
+  border-radius: 22px;
+  border: 1px dashed rgba(148, 163, 184, 0.18);
+  pointer-events: none;
+}
+
+@media (max-width: 1100px) {
+  .core-sim {
+    grid-template-columns: repeat(2, minmax(160px, 1fr));
+    grid-auto-rows: minmax(140px, auto);
+  }
+  .core-sim::before,
+  .core-sim-links {
+    display: none;
+  }
+  .node-core {
+    grid-column: 1 / -1;
+    grid-row: auto;
+  }
+  .node-ingress,
+  .node-etl,
+  .node-storage,
+  .node-gpu-ingest,
+  .node-queue-ingest,
+  .node-datalake,
+  .node-orchestration,
+  .node-model-serving,
+  .node-strategy,
+  .node-execution,
+  .node-notify,
+  .node-cpu,
+  .node-gpu-train,
+  .node-cache,
+  .node-queue-out {
+    grid-column: span 1;
+  }
+}
+
+@media (max-width: 640px) {
+  .core-sim {
+    padding: 1.5rem;
+    gap: 1rem;
+  }
+  .core-node {
+    min-height: 110px;
+  }
+  .core-node-title {
+    font-size: 0.9rem;
+  }
+  .core-node-sub {
+    font-size: 0.8rem;
+  }
 }
 .coin-name { white-space:nowrap; }
 .coin-sym { opacity:.6; font-size:.8em; margin-left:6px; text-transform:uppercase; }


### PR DESCRIPTION
## Summary
- default the COSMOS multi-chart to BTC, ETH, and XRP while adding contextual copy under the heading
- wrap the Seed AI weather widget in a scrollable 16:9 frame so the layout stays contained across viewports
- introduce a responsive core flow simulation section with gradient connectors at the bottom of the main page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db088e263c832fb6d6fe90407cdd28