### PR TITLE
Adjust Cosmos multi-chart defaults

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1395,13 +1395,13 @@
     const cryptoConfig=[
       {id:'BTC',name:'BTC',color:'#ff9500',visible:true},
       {id:'ETH',name:'ETH',color:'#627eea',visible:true},
-      {id:'BNB',name:'BNB',color:'#f0b90b',visible:true},
-      {id:'SOL',name:'SOL',color:'#9945ff',visible:true},
-      {id:'ADA',name:'ADA',color:'#0066cc',visible:true},
+      {id:'BNB',name:'BNB',color:'#f0b90b',visible:false},
+      {id:'SOL',name:'SOL',color:'#9945ff',visible:false},
+      {id:'ADA',name:'ADA',color:'#0066cc',visible:false},
       {id:'XRP',name:'XRP',color:'#00d4aa',visible:true},
-      {id:'AVAX',name:'AVAX',color:'#e84142',visible:true},
-      {id:'DOGE',name:'DOGE',color:'#c2a633',visible:true},
-      {id:'LINK',name:'LINK',color:'#2a5ada',visible:true}
+      {id:'AVAX',name:'AVAX',color:'#e84142',visible:false},
+      {id:'DOGE',name:'DOGE',color:'#c2a633',visible:false},
+      {id:'LINK',name:'LINK',color:'#2a5ada',visible:false}
     ];
 
     const TIME_RANGES={


### PR DESCRIPTION
## Summary
- disable default visibility for all Cosmos chart assets except BTC, ETH, and XRP
- keep BTC, ETH, and XRP enabled so the multi-chart loads with only those series displayed

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db25a95e70832fb53dffb6c7268902