### PR TITLE
Enhance market data caching and visualization

### DIFF
--- a/server/api/cvd.js
+++ b/server/api/cvd.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const { BUCKETS } = require('../engines/cvdEngine');
 const { normalizeTimeframe, SUPPORTED_TIMEFRAMES } = require('../utils/timeframes');
+const { createMemoryCache } = require('../utils/cache');
 
 function formatBuckets() {
   return [
@@ -13,8 +14,93 @@ function formatBuckets() {
   ];
 }
 
+const RESPONSE_CACHE = createMemoryCache({ ttlMs: 2 * 60 * 60 * 1000, maxEntries: 256 });
+
+function buildSeries(rows, buckets) {
+  const template = {};
+  buckets.forEach((bucket) => {
+    template[bucket.key] = [];
+  });
+  const deltas = {};
+  buckets.forEach((bucket) => {
+    deltas[bucket.key] = 0;
+  });
+
+  let previous = null;
+  rows.forEach((row) => {
+    const timestamp = Number(row.timestamp);
+    const values = {
+      all: Number(row.total),
+      bucket0: Number(row.bucket0),
+      bucket1: Number(row.bucket1),
+      bucket2: Number(row.bucket2),
+      bucket3: Number(row.bucket3),
+      bucket4: Number(row.bucket4),
+    };
+
+    buckets.forEach((bucket) => {
+      const val = Number(values[bucket.key]);
+      if (!Number.isFinite(timestamp) || !Number.isFinite(val)) {
+        return;
+      }
+      template[bucket.key].push([timestamp, val]);
+    });
+
+    if (previous) {
+      buckets.forEach((bucket) => {
+        const prev = Number(previous[bucket.key]);
+        const next = Number(values[bucket.key]);
+        if (Number.isFinite(prev) && Number.isFinite(next)) {
+          deltas[bucket.key] = next - prev;
+        }
+      });
+    }
+    previous = values;
+  });
+
+  return { series: template, deltas };
+}
+
+function performIntegrityChecks(series, priceSeries) {
+  if (!series || !series.all || series.all.length < 2 || !Array.isArray(priceSeries)) {
+    return { warnings: [] };
+  }
+
+  const recent = series.all.slice(-20);
+  const priceMap = new Map(priceSeries.map(([ts, val]) => [ts, val]));
+  let mismatches = 0;
+  recent.forEach(([ts, value], index) => {
+    if (index === 0) return;
+    const [prevTs, prevValue] = recent[index - 1];
+    const delta = value - prevValue;
+    const currentPrice = priceMap.get(ts);
+    const prevPrice = priceMap.get(prevTs);
+    if (!Number.isFinite(delta) || !Number.isFinite(currentPrice) || !Number.isFinite(prevPrice)) {
+      return;
+    }
+    const priceDelta = currentPrice - prevPrice;
+    if (priceDelta !== 0 && delta !== 0 && Math.sign(priceDelta) !== Math.sign(delta)) {
+      mismatches += 1;
+    }
+  });
+
+  const ratio = mismatches / Math.max(1, recent.length - 1);
+  const warnings = [];
+  if (ratio > 0.5) {
+    warnings.push({
+      type: 'cvd-sign-check',
+      ratio,
+    });
+  }
+  return { warnings };
+}
+
 module.exports = function createCvdRouter({ cvdEngine }) {
   const router = express.Router();
+
+  cvdEngine.on('minute', () => {
+    RESPONSE_CACHE.clear();
+  });
 
   router.get('/', async (req, res) => {
     const symbol = (req.query.symbol || cvdEngine.symbol || 'BTCUSDT').toUpperCase();
@@ -25,33 +111,39 @@ module.exports = function createCvdRouter({ cvdEngine }) {
       return res.status(404).json({ error: 'Symbol not tracked yet.' });
     }
 
-    try {
-      const rows = await cvdEngine.getHistory({ limit, timeframe });
-      const buckets = formatBuckets();
-      const payload = rows.map((row) => ({
-        timestamp: row.timestamp,
-        values: {
-          all: row.total,
-          bucket0: row.bucket0,
-          bucket1: row.bucket1,
-          bucket2: row.bucket2,
-          bucket3: row.bucket3,
-          bucket4: row.bucket4,
-        },
-        price: row.price,
-      }));
+    const cacheKey = [symbol, timeframe, limit];
 
-      return res.json({
-        symbol,
-        timeframe,
-        buckets,
-        points: payload,
-        meta: {
-          lastPrice: rows.length ? rows[rows.length - 1].price : null,
-          lastTimestamp: rows.length ? rows[rows.length - 1].timestamp : null,
-          timeframes: SUPPORTED_TIMEFRAMES,
-        },
+    try {
+      const payload = await RESPONSE_CACHE.wrap(cacheKey, async () => {
+        const rows = await cvdEngine.getHistory({ limit, timeframe });
+        const buckets = formatBuckets();
+        const { series, deltas } = buildSeries(rows, buckets);
+        const price = rows
+          .map((row) => {
+            const ts = Number(row.timestamp);
+            const priceValue = row.price == null ? null : Number(row.price);
+            return [ts, priceValue];
+          })
+          .filter(([ts, val]) => Number.isFinite(ts) && Number.isFinite(val));
+        const integrity = performIntegrityChecks(series, price);
+
+        return {
+          symbol,
+          timeframe,
+          buckets,
+          series,
+          price,
+          deltas,
+          meta: {
+            lastPrice: rows.length ? rows[rows.length - 1].price : null,
+            lastTimestamp: rows.length ? rows[rows.length - 1].timestamp : null,
+            timeframes: SUPPORTED_TIMEFRAMES,
+            integrity,
+          },
+        };
       });
+
+      return res.json(payload);
     } catch (error) {
       console.error('[API/CVD] Failed to load history:', error.message);
       return res.status(500).json({ error: 'Failed to load CVD history.' });

--- a/server/api/heatmap.js
+++ b/server/api/heatmap.js
@@ -1,12 +1,44 @@
 const express = require('express');
 const { normalizeTimeframe, SUPPORTED_TIMEFRAMES } = require('../utils/timeframes');
+const { createMemoryCache } = require('../utils/cache');
 
 function clamp(value, min, max) {
   return Math.min(Math.max(value, min), max);
 }
 
+function computeAdaptiveStep(range, bins) {
+  if (!Number.isFinite(range) || range <= 0 || !Number.isFinite(bins) || bins <= 0) {
+    return 1;
+  }
+  const rawStep = range / bins;
+  if (!Number.isFinite(rawStep) || rawStep <= 0) {
+    return 1;
+  }
+  const exponent = Math.floor(Math.log10(rawStep));
+  const base = 10 ** exponent;
+  const normalized = rawStep / base;
+  const candidates = [1, 2, 2.5, 5, 10];
+  const nice = candidates.find((value) => normalized <= value) || 10;
+  return nice * base;
+}
+
+function percentile(values, ratio) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return 0;
+  }
+  const sorted = values.slice().sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor(sorted.length * ratio)));
+  return sorted[index];
+}
+
+const RESPONSE_CACHE = createMemoryCache({ ttlMs: 2 * 60 * 60 * 1000, maxEntries: 64 });
+
 module.exports = function createHeatmapRouter({ heatmapEngine }) {
   const router = express.Router();
+
+  heatmapEngine.on('snapshot', () => {
+    RESPONSE_CACHE.clear();
+  });
 
   router.get('/', async (req, res) => {
     const symbol = (req.query.symbol || heatmapEngine.symbol || 'BTCUSDT').toUpperCase();
@@ -18,111 +50,124 @@ module.exports = function createHeatmapRouter({ heatmapEngine }) {
       return res.status(404).json({ error: 'Symbol not tracked yet.' });
     }
 
+    const cacheKey = [symbol, timeframe, bins, limit];
+
     try {
-      const rows = await heatmapEngine.getSnapshots({ limit, timeframe });
-      if (!rows.length) {
-        return res.json({
+      const payload = await RESPONSE_CACHE.wrap(cacheKey, async () => {
+        const rows = await heatmapEngine.getSnapshots({ limit, timeframe });
+        if (!rows.length) {
+          return {
+            symbol,
+            timeframe,
+            timestamps: [],
+            matrix: [],
+            priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+            maxValue: 0,
+            lastPrice: heatmapEngine.lastPrice,
+            meta: { timeframes: SUPPORTED_TIMEFRAMES, scale: { logBase: 10, clip: null } },
+          };
+        }
+
+        const parsed = rows.map((row) => ({
+          timestamp: Number(row.timestamp),
+          bids: JSON.parse(row.bids || '[]'),
+          asks: JSON.parse(row.asks || '[]'),
+          lastPrice: row.last_price,
+        }));
+
+        let minPrice = Number.POSITIVE_INFINITY;
+        let maxPrice = Number.NEGATIVE_INFINITY;
+        parsed.forEach((snapshot) => {
+          [...snapshot.bids, ...snapshot.asks].forEach(([price]) => {
+            const value = Number(price);
+            if (Number.isFinite(value)) {
+              minPrice = Math.min(minPrice, value);
+              maxPrice = Math.max(maxPrice, value);
+            }
+          });
+        });
+
+        if (!Number.isFinite(minPrice) || !Number.isFinite(maxPrice)) {
+          return {
+            symbol,
+            timeframe,
+            timestamps: [],
+            matrix: [],
+            priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+            maxValue: 0,
+            lastPrice: heatmapEngine.lastPrice,
+            meta: { timeframes: SUPPORTED_TIMEFRAMES, scale: { logBase: 10, clip: null } },
+          };
+        }
+
+        if (minPrice === maxPrice) {
+          const padding = Math.max(1, minPrice * 0.001);
+          minPrice -= padding;
+          maxPrice += padding;
+        }
+
+        const range = maxPrice - minPrice;
+        const step = computeAdaptiveStep(range, bins);
+        const centers = Array.from({ length: bins }, (_, idx) => minPrice + step * (idx + 0.5));
+
+        const rawValues = [];
+        const matrix = parsed.map((snapshot) => {
+          const rowValues = new Array(bins).fill(0);
+          const accumulate = (levels) => {
+            levels.forEach(([price, qty]) => {
+              const priceNum = Number(price);
+              const qtyNum = Number(qty);
+              if (!Number.isFinite(priceNum) || !Number.isFinite(qtyNum)) {
+                return;
+              }
+              const index = Math.min(
+                bins - 1,
+                Math.max(0, Math.floor((priceNum - minPrice) / step))
+              );
+              const notional = Math.abs(priceNum * qtyNum);
+              if (Number.isFinite(notional)) {
+                rowValues[index] += notional;
+                rawValues.push(notional);
+              }
+            });
+          };
+          accumulate(snapshot.bids);
+          accumulate(snapshot.asks);
+          return rowValues;
+        });
+
+        const clipThreshold = percentile(rawValues, 0.99) || 0;
+        const logMatrix = matrix.map((row) =>
+          row.map((value) => {
+            const effectiveClip = clipThreshold > 0 ? clipThreshold : value;
+            const clipped = Math.min(value, effectiveClip);
+            return Number.isFinite(clipped) && clipped > 0 ? Math.log10(1 + clipped) : 0;
+          })
+        );
+        const maxValue = logMatrix.reduce((max, row) => {
+          const local = Math.max(...row);
+          return Number.isFinite(local) ? Math.max(max, local) : max;
+        }, 0);
+
+        return {
           symbol,
           timeframe,
-          timestamps: [],
-          matrix: [],
-          priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
-          maxValue: 0,
-          lastPrice: heatmapEngine.lastPrice,
-          meta: { timeframes: SUPPORTED_TIMEFRAMES },
-        });
-      }
-
-      const parsed = rows.map((row) => ({
-        timestamp: row.timestamp,
-        bids: JSON.parse(row.bids || '[]'),
-        asks: JSON.parse(row.asks || '[]'),
-        lastPrice: row.last_price,
-      }));
-
-      let minPrice = Number.POSITIVE_INFINITY;
-      let maxPrice = Number.NEGATIVE_INFINITY;
-      parsed.forEach((snapshot) => {
-        snapshot.bids.forEach(([price]) => {
-          const value = Number(price);
-          if (Number.isFinite(value)) {
-            minPrice = Math.min(minPrice, value);
-            maxPrice = Math.max(maxPrice, value);
-          }
-        });
-        snapshot.asks.forEach(([price]) => {
-          const value = Number(price);
-          if (Number.isFinite(value)) {
-            minPrice = Math.min(minPrice, value);
-            maxPrice = Math.max(maxPrice, value);
-          }
-        });
-      });
-
-      if (!Number.isFinite(minPrice) || !Number.isFinite(maxPrice)) {
-        return res.json({
-          symbol,
-          timestamps: [],
-          matrix: [],
-          priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
-          maxValue: 0,
-          lastPrice: heatmapEngine.lastPrice,
-        });
-      }
-
-      if (minPrice === maxPrice) {
-        const padding = Math.max(1, minPrice * 0.001);
-        minPrice -= padding;
-        maxPrice += padding;
-      }
-
-      const range = maxPrice - minPrice;
-      const step = range > 0 ? range / bins : Math.max(1, minPrice * 0.001);
-      const centers = Array.from({ length: bins }, (_, idx) => minPrice + step * (idx + 0.5));
-
-      let globalMax = 0;
-      const matrix = parsed.map((snapshot) => {
-        const rowValues = new Array(bins).fill(0);
-        const accumulate = (levels) => {
-          levels.forEach(([price, qty]) => {
-            const priceNum = Number(price);
-            const qtyNum = Number(qty);
-            if (!Number.isFinite(priceNum) || !Number.isFinite(qtyNum)) {
-              return;
-            }
-            const index = Math.min(
-              bins - 1,
-              Math.max(0, Math.floor((priceNum - minPrice) / step))
-            );
-            const notional = Math.abs(priceNum * qtyNum);
-            rowValues[index] += notional;
-          });
+          timestamps: parsed.map((snapshot) => snapshot.timestamp),
+          matrix: logMatrix,
+          priceBins: {
+            count: bins,
+            min: minPrice,
+            max: maxPrice,
+            step,
+            centers,
+          },
+          maxValue,
+          lastPrice: parsed[parsed.length - 1].lastPrice ?? heatmapEngine.lastPrice,
+          meta: { timeframes: SUPPORTED_TIMEFRAMES, scale: { logBase: 10, clip: clipThreshold } },
         };
-        accumulate(snapshot.bids);
-        accumulate(snapshot.asks);
-        const localMax = Math.max(...rowValues);
-        if (Number.isFinite(localMax)) {
-          globalMax = Math.max(globalMax, localMax);
-        }
-        return rowValues;
       });
 
-      return res.json({
-        symbol,
-        timeframe,
-        timestamps: parsed.map((snapshot) => snapshot.timestamp),
-        matrix,
-        priceBins: {
-          count: bins,
-          min: minPrice,
-          max: maxPrice,
-          step,
-          centers,
-        },
-        maxValue: globalMax,
-        lastPrice: parsed[parsed.length - 1].lastPrice ?? heatmapEngine.lastPrice,
-        meta: { timeframes: SUPPORTED_TIMEFRAMES },
-      });
+      return res.json(payload);
     } catch (error) {
       console.error('[API/HEATMAP] Failed to load snapshots:', error.message);
       return res.status(500).json({ error: 'Failed to load heatmap data.' });

--- a/server/api/price.js
+++ b/server/api/price.js
@@ -1,8 +1,15 @@
 const express = require('express');
 const { normalizeTimeframe, SUPPORTED_TIMEFRAMES } = require('../utils/timeframes');
+const { createMemoryCache } = require('../utils/cache');
+
+const RESPONSE_CACHE = createMemoryCache({ ttlMs: 2 * 60 * 60 * 1000, maxEntries: 128 });
 
 module.exports = function createPriceRouter({ cvdEngine }) {
   const router = express.Router();
+
+  cvdEngine.on('minute', () => {
+    RESPONSE_CACHE.clear();
+  });
 
   router.get('/', async (req, res) => {
     const symbol = (req.query.symbol || cvdEngine.symbol || 'BTCUSDT').toUpperCase();
@@ -13,22 +20,31 @@ module.exports = function createPriceRouter({ cvdEngine }) {
       return res.status(404).json({ error: 'Symbol not tracked yet.' });
     }
 
-    try {
-      const rows = await cvdEngine.getPriceHistory({ limit, timeframe });
-      const prices = rows.map((row) => ({
-        t: row.timestamp,
-        close: row.price,
-      }));
+    const cacheKey = [symbol, timeframe, limit];
 
-      return res.json({
-        symbol,
-        timeframe,
-        prices,
-        meta: {
-          lastPrice: rows.length ? rows[rows.length - 1].price : null,
-          timeframes: SUPPORTED_TIMEFRAMES,
-        },
+    try {
+      const payload = await RESPONSE_CACHE.wrap(cacheKey, async () => {
+        const rows = await cvdEngine.getPriceHistory({ limit, timeframe });
+        const prices = rows
+          .map((row) => {
+            const ts = Number(row.timestamp);
+            const priceValue = row.price == null ? null : Number(row.price);
+            return [ts, priceValue];
+          })
+          .filter(([ts, priceValue]) => Number.isFinite(ts) && Number.isFinite(priceValue));
+
+        return {
+          symbol,
+          timeframe,
+          prices,
+          meta: {
+            lastPrice: rows.length ? rows[rows.length - 1].price : null,
+            timeframes: SUPPORTED_TIMEFRAMES,
+          },
+        };
       });
+
+      return res.json(payload);
     } catch (error) {
       console.error('[API/PRICE] Failed to load prices:', error.message);
       return res.status(500).json({ error: 'Failed to load price history.' });

--- a/server/utils/cache.js
+++ b/server/utils/cache.js
@@ -1,0 +1,72 @@
+class MemoryCache {
+  constructor({ ttlMs = 120 * 60 * 1000, maxEntries = 500 } = {}) {
+    this.ttlMs = ttlMs;
+    this.maxEntries = maxEntries;
+    this.store = new Map();
+  }
+
+  key(parts) {
+    if (Array.isArray(parts)) {
+      return parts.join('::');
+    }
+    if (typeof parts === 'object' && parts !== null) {
+      return JSON.stringify(parts);
+    }
+    return String(parts);
+  }
+
+  get(rawKey) {
+    const key = this.key(rawKey);
+    const entry = this.store.get(key);
+    if (!entry) {
+      return null;
+    }
+    if (Date.now() > entry.expiresAt) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  set(rawKey, value, ttlOverride) {
+    const key = this.key(rawKey);
+    const ttlMs = Number.isFinite(ttlOverride) ? ttlOverride : this.ttlMs;
+    const expiresAt = Date.now() + ttlMs;
+
+    if (this.store.size >= this.maxEntries) {
+      const firstKey = this.store.keys().next().value;
+      if (firstKey) {
+        this.store.delete(firstKey);
+      }
+    }
+
+    this.store.set(key, { value, expiresAt });
+    return value;
+  }
+
+  wrap(rawKey, loader, ttlOverride) {
+    const cached = this.get(rawKey);
+    if (cached !== null && cached !== undefined) {
+      return Promise.resolve(cached);
+    }
+    return Promise.resolve()
+      .then(loader)
+      .then((value) => {
+        this.set(rawKey, value, ttlOverride);
+        return value;
+      });
+  }
+
+  clear() {
+    this.store.clear();
+  }
+}
+
+function createMemoryCache(options) {
+  return new MemoryCache(options);
+}
+
+module.exports = {
+  MemoryCache,
+  createMemoryCache,
+};


### PR DESCRIPTION
## Summary
- add a reusable in-memory cache with engine-driven invalidation for CVD, heatmap, and price endpoints and emit integrity metadata
- harden CVD/heatmap engines with exponential backoff, rolling backfill, log-scaled heatmap values, and percentile clipping
- refresh cosmos dashboard parsing to consume new lightweight payloads, convert log liquidity back for tooltips, and synchronize hover tooltips across charts

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68db96ebe1cc832f92a0dd644163e3fc