### PR TITLE
Adjust heatmap legend spacing

### DIFF
--- a/apps/web/menu/cosmos/cvd-heatmap.js
+++ b/apps/web/menu/cosmos/cvd-heatmap.js
@@ -385,7 +385,7 @@
         max: maxValue,
         calculable: true,
         orient: 'vertical',
-        right: 18,
+        right: 68,
         top: 'center',
         text: ['HIGH', 'LOW'],
         itemHeight: 200,


### PR DESCRIPTION
## Summary
- move the heatmap legend further from the right axis to avoid overlapping labels

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbb455ce38832f9ba8f323096fd026