### PR TITLE
Add Binance futures liquidation heatmap experience

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ pnpm-debug.log*
 
 # Misc
 .DS_Store
+data/*.sqlite*
 
 # Temporary files
 tmp/

--- a/apps/web/menu/cosmos/index.html
+++ b/apps/web/menu/cosmos/index.html
@@ -1583,6 +1583,15 @@
           <span class="twofive-link__badge">NEW</span>
         </span>
       </a>
+      <a class="twofive-link neon-dashboard-link" href="/menu/cosmos/liquidation-heatmap.html"
+         title="Futures Liquidation Heatmap"
+         aria-label="Futures Liquidation Heatmap 바로가기">
+        <span class="twofive-link__icon" aria-hidden="true">🔥</span>
+        <span class="twofive-link__meta">
+          <span>Liquidation Heatmap</span>
+          <span class="twofive-link__badge">BETA</span>
+        </span>
+      </a>
       <input class="search" id="q" type="text" placeholder="🔍 Search cryptocurrency (name/symbol)">
     </div>
     

--- a/apps/web/menu/cosmos/liquidation-heatmap.css
+++ b/apps/web/menu/cosmos/liquidation-heatmap.css
@@ -1,0 +1,359 @@
+:root {
+  color-scheme: dark;
+  --bg: radial-gradient(circle at 20% 20%, rgba(93, 12, 255, 0.35), transparent 55%),
+         radial-gradient(circle at 80% 80%, rgba(255, 0, 128, 0.25), transparent 60%),
+         #05020d;
+  --panel-bg: rgba(15, 10, 30, 0.55);
+  --panel-border: rgba(118, 67, 255, 0.35);
+  --text-main: #f1f5ff;
+  --text-muted: #8d93b5;
+  --accent: #8c5bff;
+  --accent-strong: #ff2fb5;
+  --badge-bg: rgba(12, 243, 255, 0.12);
+  --badge-color: #4de8ff;
+  --success: #00f7ff;
+  --warn: #ff7ac7;
+  --font-heading: 'Orbitron', sans-serif;
+  --font-body: 'Rajdhani', sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg);
+  font-family: var(--font-body);
+  color: var(--text-main);
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+.background {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background-image:
+    radial-gradient(circle at 10% 10%, rgba(0, 255, 255, 0.18), transparent 60%),
+    radial-gradient(circle at 80% 20%, rgba(255, 0, 128, 0.15), transparent 60%),
+    radial-gradient(circle at 50% 80%, rgba(120, 0, 255, 0.2), transparent 55%);
+  filter: blur(40px);
+  opacity: 0.75;
+  z-index: 0;
+}
+
+.page-header {
+  position: relative;
+  z-index: 2;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px clamp(16px, 4vw, 32px) 12px;
+}
+
+.back-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-main);
+  text-decoration: none;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(139, 92, 246, 0.35);
+  background: rgba(9, 5, 24, 0.65);
+  box-shadow: 0 0 18px rgba(120, 72, 255, 0.25);
+  font-family: var(--font-heading);
+  font-size: 0.95rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.back-link:hover,
+.back-link:focus-visible {
+  border-color: rgba(139, 92, 246, 0.8);
+  box-shadow: 0 0 24px rgba(120, 72, 255, 0.45);
+}
+
+.header-meta {
+  text-align: right;
+}
+
+.header-meta h1 {
+  font-family: var(--font-heading);
+  font-size: clamp(1.6rem, 2.6vw, 2.4rem);
+  margin: 0;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.header-meta p {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.page-main {
+  position: relative;
+  z-index: 2;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 0 clamp(16px, 4vw, 32px) 40px;
+}
+
+.control-panel {
+  display: grid;
+  grid-template-columns: minmax(200px, 260px) 1fr minmax(220px, 260px);
+  gap: 16px;
+  align-items: center;
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 18px;
+  padding: 18px clamp(16px, 3vw, 28px);
+  box-shadow: 0 24px 40px rgba(6, 2, 20, 0.45);
+}
+
+.symbol-picker label {
+  display: block;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  margin-bottom: 6px;
+}
+
+.symbol-input {
+  width: 100%;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(99, 102, 241, 0.4);
+  background: rgba(8, 6, 22, 0.8);
+  color: var(--text-main);
+  font-size: 1.05rem;
+  font-family: var(--font-heading);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.symbol-input:focus {
+  outline: none;
+  border-color: rgba(99, 102, 241, 0.75);
+  box-shadow: 0 0 18px rgba(99, 102, 241, 0.35);
+}
+
+.range-picker {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.range-button {
+  min-width: 58px;
+  padding: 10px 14px;
+  border-radius: 12px;
+  border: 1px solid rgba(79, 70, 229, 0.4);
+  background: rgba(12, 8, 28, 0.6);
+  color: var(--text-main);
+  font-family: var(--font-heading);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  cursor: pointer;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+}
+
+.range-button:hover,
+.range-button:focus-visible {
+  border-color: rgba(148, 163, 255, 0.85);
+  box-shadow: 0 0 22px rgba(99, 102, 241, 0.45);
+  outline: none;
+}
+
+.range-button.active {
+  background: linear-gradient(135deg, rgba(92, 70, 255, 0.85), rgba(255, 51, 187, 0.75));
+  border-color: rgba(255, 51, 187, 0.9);
+  color: #fff;
+  box-shadow: 0 0 25px rgba(255, 51, 187, 0.45);
+}
+
+.totals {
+  display: flex;
+  justify-content: flex-end;
+  gap: 16px;
+}
+
+.totals .label {
+  display: block;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.totals .value {
+  font-size: 1.1rem;
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
+}
+
+.totals div:first-child .value {
+  color: var(--warn);
+}
+
+.totals div:nth-child(2) .value {
+  color: var(--success);
+}
+
+.chart-panel {
+  background: var(--panel-bg);
+  border: 1px solid var(--panel-border);
+  border-radius: 20px;
+  padding: clamp(18px, 3vw, 28px);
+  box-shadow: 0 28px 48px rgba(8, 4, 24, 0.55);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-family: var(--font-heading);
+  font-size: 1.4rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.panel-description {
+  margin: 6px 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.panel-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  justify-content: flex-end;
+}
+
+.meta-label {
+  display: block;
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.meta-value {
+  font-size: 1.05rem;
+  font-family: var(--font-heading);
+  letter-spacing: 0.08em;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: var(--badge-bg);
+  color: var(--badge-color);
+  font-family: var(--font-heading);
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.status-pill[data-state='loading'] {
+  background: rgba(255, 170, 0, 0.18);
+  color: #ffd166;
+}
+
+.status-pill[data-state='error'] {
+  background: rgba(255, 0, 128, 0.18);
+  color: #ff66b3;
+}
+
+.status-pill[data-state='online'] {
+  background: rgba(0, 255, 204, 0.18);
+  color: #7dffe3;
+}
+
+.chart {
+  position: relative;
+  height: clamp(420px, 60vh, 620px);
+}
+
+.empty-state {
+  text-align: center;
+  padding: 24px;
+  border-radius: 16px;
+  border: 1px dashed rgba(148, 163, 255, 0.3);
+  background: rgba(10, 8, 26, 0.55);
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.page-footer {
+  position: relative;
+  z-index: 2;
+  text-align: center;
+  padding: 18px 16px 28px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+@media (max-width: 960px) {
+  .page-header {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 16px;
+  }
+
+  .header-meta {
+    text-align: left;
+  }
+
+  .control-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .totals {
+    justify-content: space-between;
+  }
+
+  .panel-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .panel-meta {
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 600px) {
+  .chart {
+    height: 360px;
+  }
+
+  .range-picker {
+    justify-content: flex-start;
+  }
+
+  .range-button {
+    flex: 1 1 calc(33% - 8px);
+  }
+}

--- a/apps/web/menu/cosmos/liquidation-heatmap.html
+++ b/apps/web/menu/cosmos/liquidation-heatmap.html
@@ -1,0 +1,91 @@
+<!doctype html>
+<html lang="ko">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+  <meta name="theme-color" content="#070312" />
+  <title>TWO.4 · Liquidation Heatmap</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron:wght@500;700&family=Rajdhani:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="./liquidation-heatmap.css" />
+</head>
+<body>
+  <div class="background" aria-hidden="true"></div>
+  <header class="page-header">
+    <a class="back-link" href="/menu/cosmos/">
+      <span aria-hidden="true">⭠</span>
+      <span>Cosmos Hub</span>
+    </a>
+    <div class="header-meta">
+      <h1>Liquidation Heatmap</h1>
+      <p>Binance Futures · Top 30 USDT pairs · 실시간 청산 히트맵</p>
+    </div>
+  </header>
+
+  <main class="page-main">
+    <section class="control-panel" aria-label="Liquidation controls">
+      <div class="symbol-picker">
+        <label for="symbolInput">Symbol</label>
+        <input id="symbolInput" class="symbol-input" type="search" placeholder="BTCUSDT" list="symbolList" autocomplete="off" />
+        <datalist id="symbolList"></datalist>
+      </div>
+      <div class="range-picker" role="group" aria-label="Select history range">
+        <button type="button" class="range-button" data-range="12h">12h</button>
+        <button type="button" class="range-button" data-range="1d">1d</button>
+        <button type="button" class="range-button" data-range="3d">3d</button>
+        <button type="button" class="range-button" data-range="1w">1w</button>
+        <button type="button" class="range-button" data-range="2w">2w</button>
+      </div>
+      <div class="totals" aria-live="polite">
+        <div>
+          <span class="label">Long Liq.</span>
+          <span class="value" data-total-long>--</span>
+        </div>
+        <div>
+          <span class="label">Short Liq.</span>
+          <span class="value" data-total-short>--</span>
+        </div>
+        <div>
+          <span class="label">Events</span>
+          <span class="value" data-total-count>--</span>
+        </div>
+      </div>
+    </section>
+
+    <section class="chart-panel" aria-labelledby="heatmapTitle">
+      <div class="panel-header">
+        <div>
+          <h2 id="heatmapTitle">Liquidation Heatmap</h2>
+          <p class="panel-description">가격-시간 축으로 집계된 청산 공백 · 진한 색상일수록 더 큰 청산 규모</p>
+        </div>
+        <div class="panel-meta">
+          <div>
+            <span class="meta-label">Last Price</span>
+            <span class="meta-value" data-last-price>--</span>
+          </div>
+          <div>
+            <span class="meta-label">Updated</span>
+            <span class="meta-value" data-updated>--</span>
+          </div>
+          <div>
+            <span class="meta-label">Status</span>
+            <span class="status-pill" data-status>Initializing</span>
+          </div>
+        </div>
+      </div>
+      <div class="chart" id="heatmapChart" role="img" aria-label="Liquidation heatmap"></div>
+      <div class="empty-state" data-empty hidden>
+        <p>아직 축적된 청산 데이터가 없습니다. 잠시 후 다시 확인해주세요.</p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="page-footer">
+    Data sourced from Binance Futures force-order streams · 저장소: SQLite · 업데이트 간격: 실시간
+  </footer>
+
+  <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
+  <script src="./liquidation-heatmap.js" defer></script>
+</body>
+</html>

--- a/apps/web/menu/cosmos/liquidation-heatmap.js
+++ b/apps/web/menu/cosmos/liquidation-heatmap.js
@@ -1,0 +1,397 @@
+(function () {
+  const RANGE_PRESETS = {
+    '12h': { tf: '1m', limit: 720 },
+    '1d': { tf: '1m', limit: 1440 },
+    '3d': { tf: '5m', limit: 864 },
+    '1w': { tf: '15m', limit: 672 },
+    '2w': { tf: '1h', limit: 336 },
+  };
+  const symbolInput = document.getElementById('symbolInput');
+  const symbolList = document.getElementById('symbolList');
+  const buttons = Array.from(document.querySelectorAll('.range-button'));
+  const totalLongEl = document.querySelector('[data-total-long]');
+  const totalShortEl = document.querySelector('[data-total-short]');
+  const totalCountEl = document.querySelector('[data-total-count]');
+  const lastPriceEl = document.querySelector('[data-last-price]');
+  const updatedEl = document.querySelector('[data-updated]');
+  const statusEl = document.querySelector('[data-status]');
+  const emptyState = document.querySelector('[data-empty]');
+  const chartEl = document.getElementById('heatmapChart');
+
+  if (!symbolInput || !symbolList || !chartEl) {
+    console.warn('[LiqHeatmap] Missing required elements.');
+    return;
+  }
+
+  const chart = echarts.init(chartEl);
+  const numberFormatter = new Intl.NumberFormat('en-US');
+  const compactFormatter = new Intl.NumberFormat('en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  });
+  const timeFormatter = new Intl.DateTimeFormat('ko-KR', {
+    dateStyle: 'short',
+    timeStyle: 'medium',
+  });
+
+  const state = {
+    symbols: [],
+    symbol: null,
+    rangeKey: '12h',
+    loading: false,
+    abortController: null,
+  };
+
+  function formatNotional(value) {
+    if (!Number.isFinite(value)) {
+      return '--';
+    }
+    if (value < 1) {
+      return value.toFixed(2);
+    }
+    return compactFormatter.format(value);
+  }
+
+  function formatUsd(value) {
+    if (!Number.isFinite(value)) {
+      return '--';
+    }
+    return `$${formatNotional(value)}`;
+  }
+
+  function formatPrice(value) {
+    if (!Number.isFinite(value)) {
+      return '--';
+    }
+    const abs = Math.abs(value);
+    let digits = 2;
+    if (abs < 1) {
+      digits = 4;
+    }
+   if (abs < 0.01) {
+     digits = 6;
+   }
+    const fixed = Number(value).toFixed(digits);
+    return numberFormatter.format(Number(fixed));
+  }
+
+  function setStatus(text, tone = 'default') {
+    if (!statusEl) return;
+    statusEl.textContent = text;
+    statusEl.dataset.state = tone;
+  }
+
+  function setLoading(loading) {
+    state.loading = loading;
+    if (loading) {
+      setStatus('Loading…', 'loading');
+    }
+  }
+
+  function setActiveRange(rangeKey) {
+    buttons.forEach((btn) => {
+      if (btn.dataset.range === rangeKey) {
+        btn.classList.add('active');
+      } else {
+        btn.classList.remove('active');
+      }
+    });
+  }
+
+  function setEmptyVisible(visible) {
+    if (!emptyState) return;
+    emptyState.hidden = !visible;
+    if (visible) {
+      chart.clear();
+    }
+  }
+
+  function buildHeatmapOption(payload) {
+    if (!payload || !Array.isArray(payload.timestamps) || !payload.timestamps.length) {
+      return null;
+    }
+    const centers = payload.priceBins?.centers || [];
+    const heatmapData = [];
+    payload.matrix.forEach((row, rowIndex) => {
+      const ts = payload.timestamps[rowIndex];
+      row.forEach((value, colIndex) => {
+        const price = centers[colIndex];
+        if (!Number.isFinite(price)) {
+          return;
+        }
+        heatmapData.push([ts, price, Number(value)]);
+      });
+    });
+
+    const priceSeries = Array.isArray(payload.priceSeries)
+      ? payload.priceSeries.filter((point) => Number.isFinite(point?.[1]))
+      : [];
+
+    const maxValue = Math.max(1, Number(payload.maxValue) || 0);
+    const clip = Number(payload.meta?.clip) || 0;
+
+    return {
+      animation: false,
+      backgroundColor: 'transparent',
+      grid: {
+        top: 24,
+        left: 60,
+        right: 20,
+        bottom: 40,
+      },
+      tooltip: {
+        trigger: 'item',
+        axisPointer: {
+          type: 'cross',
+        },
+        formatter: (params) => {
+          if (!params || !Array.isArray(params.value)) {
+            return '';
+          }
+          const [ts, price, logValue] = params.value;
+          const approx = Math.pow(10, logValue) - 1;
+          const clipped = clip > 0 ? Math.min(approx, clip) : approx;
+          const priceText = formatPrice(price);
+          const notionalText = formatUsd(clipped);
+          const timeText = Number.isFinite(ts) ? timeFormatter.format(new Date(ts)) : '--';
+          return [
+            `<strong>${timeText}</strong>`,
+            `가격: ${priceText}`,
+            `청산 규모: ${notionalText}`,
+          ].join('<br>');
+        },
+      },
+      xAxis: {
+        type: 'time',
+        axisLabel: {
+          color: '#dbe2ff',
+        },
+        splitLine: {
+          show: false,
+        },
+      },
+      yAxis: {
+        type: 'value',
+        inverse: true,
+        min: payload.priceBins?.min ?? null,
+        max: payload.priceBins?.max ?? null,
+        axisLabel: {
+          color: '#dbe2ff',
+          formatter: (value) => formatPrice(value),
+        },
+        splitLine: {
+          lineStyle: {
+            color: 'rgba(148, 163, 255, 0.15)',
+          },
+        },
+      },
+      visualMap: {
+        show: false,
+        min: 0,
+        max: maxValue,
+        calculable: false,
+        inRange: {
+          color: [
+            'rgba(20,16,40,0.05)',
+            '#2a0d55',
+            '#7a1f9c',
+            '#ff3399',
+            '#ffe873',
+          ],
+        },
+      },
+      series: [
+        {
+          type: 'heatmap',
+          name: 'Liquidations',
+          data: heatmapData,
+          progressive: 0,
+          emphasis: {
+            focus: 'series',
+          },
+        },
+        {
+          type: 'line',
+          name: 'Weighted Price',
+          data: priceSeries,
+          showSymbol: false,
+          smooth: true,
+          lineStyle: {
+            color: '#66e4ff',
+            width: 2,
+            opacity: 0.9,
+          },
+          itemStyle: {
+            color: '#66e4ff',
+          },
+          zlevel: 2,
+        },
+      ],
+    };
+  }
+
+  function updateTotals(payload) {
+    const totals = payload?.totals || {};
+    if (totalLongEl) {
+      totalLongEl.textContent = formatUsd(Number(totals.long));
+    }
+    if (totalShortEl) {
+      totalShortEl.textContent = formatUsd(Number(totals.short));
+    }
+    if (totalCountEl) {
+      totalCountEl.textContent = numberFormatter.format(Number(totals.count) || 0);
+    }
+  }
+
+  function updateMeta(payload) {
+    const lastPrice = Number(payload?.meta?.lastPrice);
+    if (lastPriceEl) {
+      lastPriceEl.textContent = formatPrice(lastPrice);
+    }
+    const timestamps = payload?.timestamps || [];
+    if (updatedEl) {
+      if (timestamps.length) {
+        const ts = timestamps[timestamps.length - 1];
+        updatedEl.textContent = timeFormatter.format(new Date(ts));
+      } else {
+        updatedEl.textContent = '--';
+      }
+    }
+    setStatus('Online', 'online');
+  }
+
+  function render(payload) {
+    if (!payload || !Array.isArray(payload.timestamps) || payload.timestamps.length === 0) {
+      setEmptyVisible(true);
+      updateTotals(payload);
+      updateMeta(payload);
+      return;
+    }
+    setEmptyVisible(false);
+    const option = buildHeatmapOption(payload);
+    if (option) {
+      chart.setOption(option, true);
+    }
+    updateTotals(payload);
+    updateMeta(payload);
+  }
+
+  async function loadSymbols() {
+    try {
+      const response = await fetch('/api/liquidations/symbols');
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const data = await response.json();
+      const symbols = Array.isArray(data?.symbols) ? data.symbols : [];
+      state.symbols = symbols;
+      symbolList.innerHTML = '';
+      symbols.forEach((item) => {
+        const option = document.createElement('option');
+        option.value = item.symbol;
+        const volume = Number(item.quoteVolume);
+        option.textContent = volume
+          ? `${item.symbol} · ${formatNotional(volume)} USDT`
+          : item.symbol;
+        symbolList.appendChild(option);
+      });
+      if (!state.symbol && symbols.length) {
+        state.symbol = symbols[0].symbol;
+      }
+      if (state.symbol) {
+        symbolInput.value = state.symbol;
+        await loadData();
+      }
+    } catch (error) {
+      console.error('[LiqHeatmap] Failed to load symbols:', error);
+      setStatus('Symbol load error', 'error');
+    }
+  }
+
+  async function loadData() {
+    if (!state.symbol) {
+      return;
+    }
+    const preset = RANGE_PRESETS[state.rangeKey] || RANGE_PRESETS['12h'];
+    const params = new URLSearchParams({
+      symbol: state.symbol,
+      tf: preset.tf,
+      limit: String(preset.limit),
+      bins: '160',
+    });
+
+    if (state.abortController) {
+      state.abortController.abort();
+    }
+    const controller = new AbortController();
+    state.abortController = controller;
+
+    try {
+      setLoading(true);
+      const response = await fetch(`/api/liquidations?${params.toString()}`, {
+        signal: controller.signal,
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      const payload = await response.json();
+      render(payload);
+    } catch (error) {
+      if (error.name === 'AbortError') {
+        return;
+      }
+      console.error('[LiqHeatmap] Failed to load data:', error);
+      setStatus('Error', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  function handleSymbolChange() {
+    const value = String(symbolInput.value || '').trim().toUpperCase();
+    if (!value) {
+      return;
+    }
+    const known = state.symbols.find((item) => item.symbol === value);
+    if (!known) {
+      // revert to previous valid symbol
+      symbolInput.value = state.symbol || '';
+      return;
+    }
+    if (value === state.symbol) {
+      return;
+    }
+    state.symbol = value;
+    loadData();
+  }
+
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const key = button.dataset.range;
+      if (!key || key === state.rangeKey) {
+        return;
+      }
+      if (!RANGE_PRESETS[key]) {
+        return;
+      }
+      state.rangeKey = key;
+      setActiveRange(key);
+      loadData();
+    });
+  });
+
+  symbolInput.addEventListener('change', handleSymbolChange);
+  symbolInput.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      handleSymbolChange();
+      event.preventDefault();
+    }
+  });
+
+  setActiveRange(state.rangeKey);
+  loadSymbols();
+
+  window.addEventListener('resize', () => {
+    chart.resize();
+  });
+})();

--- a/server.js
+++ b/server.js
@@ -9,8 +9,10 @@ const createNewsKoRouter = require('./routes/news-ko');
 const { getDatabase } = require('./server/database');
 const { CVDEngine } = require('./server/engines/cvdEngine');
 const { HeatmapEngine } = require('./server/engines/heatmapEngine');
+const { LiquidationHeatmapEngine } = require('./server/engines/liquidationHeatmapEngine');
 const createCvdRouter = require('./server/api/cvd');
 const createHeatmapRouter = require('./server/api/heatmap');
+const createLiquidationHeatmapRouter = require('./server/api/liquidation-heatmap');
 const createPriceRouter = require('./server/api/price');
 const createSeedWeatherRouter = require('./server/api/seed-weather');
 
@@ -20,12 +22,15 @@ const PORT = process.env.COSMOS_PORT || process.env.PORT || 3000;
 const marketDb = getDatabase();
 const cvdEngine = new CVDEngine({ db: marketDb, symbol: 'BTCUSDT' });
 const heatmapEngine = new HeatmapEngine({ db: marketDb, symbol: 'BTCUSDT' });
+const liquidationEngine = new LiquidationHeatmapEngine({ db: marketDb });
 
 cvdEngine.start();
 heatmapEngine.start();
+liquidationEngine.start();
 
 const cvdRouter = createCvdRouter({ cvdEngine });
 const heatmapRouter = createHeatmapRouter({ heatmapEngine });
+const liquidationRouter = createLiquidationHeatmapRouter({ liquidationEngine });
 const priceRouter = createPriceRouter({ cvdEngine });
 const seedWeatherRouter = createSeedWeatherRouter();
 
@@ -334,6 +339,7 @@ orbitsRouter.delete('/posts/:id', (req, res) => {
 
 app.use('/api/cvd', cvdRouter);
 app.use('/api/heatmap', heatmapRouter);
+app.use('/api/liquidations', liquidationRouter);
 app.use('/api/price', priceRouter);
 app.use('/api/seed-weather', seedWeatherRouter);
 app.use('/api/orbits', orbitsRouter);
@@ -1426,6 +1432,7 @@ function gracefulShutdown(signal) {
   try {
     cvdEngine.stop();
     heatmapEngine.stop();
+    liquidationEngine.stop();
   } catch (error) {
     console.error('Failed to stop market engines:', error.message);
   }

--- a/server/api/liquidation-heatmap.js
+++ b/server/api/liquidation-heatmap.js
@@ -1,0 +1,225 @@
+const express = require('express');
+const {
+  normalizeTimeframe,
+  timeframeToMs,
+  SUPPORTED_TIMEFRAMES,
+} = require('../utils/timeframes');
+const { createMemoryCache } = require('../utils/cache');
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function computeAdaptiveStep(range, bins) {
+  if (!Number.isFinite(range) || range <= 0 || !Number.isFinite(bins) || bins <= 0) {
+    return 1;
+  }
+  const rawStep = range / bins;
+  if (!Number.isFinite(rawStep) || rawStep <= 0) {
+    return 1;
+  }
+  const exponent = Math.floor(Math.log10(rawStep));
+  const base = 10 ** exponent;
+  const normalized = rawStep / base;
+  const candidates = [1, 2, 2.5, 5, 10];
+  const nice = candidates.find((value) => normalized <= value) || 10;
+  return nice * base;
+}
+
+function percentile(values, ratio) {
+  if (!Array.isArray(values) || values.length === 0) {
+    return 0;
+  }
+  const sorted = values.slice().sort((a, b) => a - b);
+  const index = Math.min(sorted.length - 1, Math.max(0, Math.floor(sorted.length * ratio)));
+  return sorted[index];
+}
+
+const RESPONSE_CACHE = createMemoryCache({ ttlMs: 5 * 60 * 1000, maxEntries: 256 });
+
+module.exports = function createLiquidationHeatmapRouter({ liquidationEngine }) {
+  const router = express.Router();
+
+  liquidationEngine.on('event', () => {
+    RESPONSE_CACHE.clear();
+  });
+  liquidationEngine.on('symbols', () => {
+    RESPONSE_CACHE.clear();
+  });
+
+  router.get('/symbols', (_req, res) => {
+    const symbols = liquidationEngine.getSymbols();
+    res.json({ symbols });
+  });
+
+  router.get('/', async (req, res) => {
+    const symbol = String(req.query.symbol || '').toUpperCase() || liquidationEngine.getSymbols()[0]?.symbol || 'BTCUSDT';
+    const timeframe = normalizeTimeframe(req.query.tf, '1m');
+    const bins = clamp(Number.parseInt(req.query.bins, 10) || 160, 20, 600);
+    const limit = clamp(Number.parseInt(req.query.limit, 10) || 720, 20, 5000);
+
+    if (!symbol) {
+      return res.status(400).json({ error: 'Symbol is required.' });
+    }
+
+    const cacheKey = [symbol, timeframe, bins, limit];
+
+    try {
+      const payload = await RESPONSE_CACHE.wrap(cacheKey, async () => {
+        const rows = await liquidationEngine.getEvents({ symbol, timeframe, limit });
+        if (!Array.isArray(rows) || !rows.length) {
+          return {
+            symbol,
+            timeframe,
+            timestamps: [],
+            matrix: [],
+            priceSeries: [],
+            totals: { long: 0, short: 0, count: 0 },
+            priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+            maxValue: 0,
+            meta: {
+              timeframes: SUPPORTED_TIMEFRAMES,
+              lastPrice: liquidationEngine.getLastPrice(symbol),
+              clip: null,
+            },
+          };
+        }
+
+        let minPrice = Number.POSITIVE_INFINITY;
+        let maxPrice = Number.NEGATIVE_INFINITY;
+        rows.forEach((row) => {
+          const price = Number(row.price);
+          if (Number.isFinite(price)) {
+            minPrice = Math.min(minPrice, price);
+            maxPrice = Math.max(maxPrice, price);
+          }
+        });
+
+        if (!Number.isFinite(minPrice) || !Number.isFinite(maxPrice)) {
+          return {
+            symbol,
+            timeframe,
+            timestamps: [],
+            matrix: [],
+            priceSeries: [],
+            totals: { long: 0, short: 0, count: 0 },
+            priceBins: { count: bins, min: null, max: null, step: null, centers: [] },
+            maxValue: 0,
+            meta: {
+              timeframes: SUPPORTED_TIMEFRAMES,
+              lastPrice: liquidationEngine.getLastPrice(symbol),
+              clip: null,
+            },
+          };
+        }
+
+        if (minPrice === maxPrice) {
+          const pad = Math.max(1, minPrice * 0.001);
+          minPrice -= pad;
+          maxPrice += pad;
+        }
+
+        const range = maxPrice - minPrice;
+        const step = computeAdaptiveStep(range, bins);
+        const centers = Array.from({ length: bins }, (_, idx) => minPrice + step * (idx + 0.5));
+
+        const bucketMs = timeframeToMs(timeframe) || 60_000;
+        const bucketMap = new Map();
+        const rawValues = [];
+        let totalLong = 0;
+        let totalShort = 0;
+
+        rows.forEach((row) => {
+          const ts = Number(row.event_time);
+          const price = Number(row.price);
+          const notional = Number(row.notional);
+          const side = String(row.side || '').toUpperCase();
+          if (!Number.isFinite(ts) || !Number.isFinite(price) || !Number.isFinite(notional)) {
+            return;
+          }
+          const bucketTs = Math.floor(ts / bucketMs) * bucketMs;
+          const binIdx = Math.min(bins - 1, Math.max(0, Math.floor((price - minPrice) / step)));
+          if (!bucketMap.has(bucketTs)) {
+            bucketMap.set(bucketTs, {
+              values: new Array(bins).fill(0),
+              priceSum: 0,
+              notionalSum: 0,
+              long: 0,
+              short: 0,
+            });
+          }
+          const bucket = bucketMap.get(bucketTs);
+          bucket.values[binIdx] += notional;
+          bucket.priceSum += price * notional;
+          bucket.notionalSum += notional;
+          if (side === 'SELL') {
+            bucket.long += notional;
+            totalLong += notional;
+          } else if (side === 'BUY') {
+            bucket.short += notional;
+            totalShort += notional;
+          }
+          rawValues.push(notional);
+        });
+
+        const timestamps = Array.from(bucketMap.keys()).sort((a, b) => a - b);
+        const logMatrix = [];
+        const priceSeries = [];
+        const longSeries = [];
+        const shortSeries = [];
+
+        const clipThreshold = percentile(rawValues, 0.99) || 0;
+
+        timestamps.forEach((ts) => {
+          const bucket = bucketMap.get(ts);
+          if (!bucket) {
+            return;
+          }
+          const logRow = bucket.values.map((value) => {
+            const effectiveClip = clipThreshold > 0 ? clipThreshold : value;
+            const clipped = Math.min(value, effectiveClip);
+            return Number.isFinite(clipped) && clipped > 0 ? Math.log10(1 + clipped) : 0;
+          });
+          logMatrix.push(logRow);
+          if (bucket.notionalSum > 0) {
+            priceSeries.push([ts, bucket.priceSum / bucket.notionalSum]);
+          } else {
+            priceSeries.push([ts, null]);
+          }
+          longSeries.push([ts, bucket.long]);
+          shortSeries.push([ts, bucket.short]);
+        });
+
+        const maxValue = logMatrix.reduce((max, row) => {
+          const local = Math.max(...row);
+          return Number.isFinite(local) ? Math.max(max, local) : max;
+        }, 0);
+
+        return {
+          symbol,
+          timeframe,
+          timestamps,
+          matrix: logMatrix,
+          priceSeries,
+          longSeries,
+          shortSeries,
+          totals: { long: totalLong, short: totalShort, count: rows.length },
+          priceBins: { count: bins, min: minPrice, max: maxPrice, step, centers },
+          maxValue,
+          meta: {
+            timeframes: SUPPORTED_TIMEFRAMES,
+            lastPrice: liquidationEngine.getLastPrice(symbol),
+            clip: clipThreshold,
+          },
+        };
+      });
+
+      return res.json(payload);
+    } catch (error) {
+      console.error('[API/LIQ] Failed to load liquidation heatmap:', error.message);
+      return res.status(500).json({ error: 'Failed to load liquidation heatmap data.' });
+    }
+  });
+
+  return router;
+};

--- a/server/engines/liquidationHeatmapEngine.js
+++ b/server/engines/liquidationHeatmapEngine.js
@@ -1,0 +1,300 @@
+const EventEmitter = require('events');
+const WebSocket = require('ws');
+const fetch = require('node-fetch');
+
+const { timeframeToMs, normalizeTimeframe } = require('../utils/timeframes');
+
+const BINANCE_FUTURES_API = 'https://fapi.binance.com';
+const BINANCE_FUTURES_WS = 'wss://fstream.binance.com/ws';
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+class LiquidationHeatmapEngine extends EventEmitter {
+  constructor({ db, topSymbols = 30, retentionDays = 14 } = {}) {
+    super();
+    this.db = db;
+    this.topSymbols = topSymbols;
+    this.retentionDays = retentionDays;
+
+    this.symbols = [];
+    this.symbolMeta = new Map(); // symbol -> { lastPrice, quoteVolume }
+    this.streams = new Map(); // symbol -> { ws, retry }
+    this.lastPrices = new Map();
+
+    this.refreshTimer = null;
+    this.pruneTimer = null;
+
+    this.initTable();
+  }
+
+  initTable() {
+    this.db.serialize(() => {
+      this.db.run(`
+        CREATE TABLE IF NOT EXISTS liquidation_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          symbol TEXT NOT NULL,
+          event_time INTEGER NOT NULL,
+          side TEXT NOT NULL,
+          price REAL NOT NULL,
+          quantity REAL NOT NULL,
+          notional REAL NOT NULL,
+          created_at INTEGER NOT NULL DEFAULT (strftime('%s','now') * 1000),
+          UNIQUE(symbol, event_time, side, price, quantity)
+        )
+      `);
+      this.db.run('CREATE INDEX IF NOT EXISTS idx_liq_symbol_time ON liquidation_events(symbol, event_time DESC)');
+      this.db.run('CREATE INDEX IF NOT EXISTS idx_liq_time ON liquidation_events(event_time DESC)');
+    });
+  }
+
+  start() {
+    this.refreshSymbols();
+    this.refreshTimer = setInterval(() => this.refreshSymbols(), 30 * 60 * 1000);
+    this.refreshTimer.unref?.();
+    this.pruneTimer = setInterval(() => this.pruneOldEvents(), 60 * 60 * 1000);
+    this.pruneTimer.unref?.();
+  }
+
+  stop() {
+    if (this.refreshTimer) {
+      clearInterval(this.refreshTimer);
+      this.refreshTimer = null;
+    }
+    if (this.pruneTimer) {
+      clearInterval(this.pruneTimer);
+      this.pruneTimer = null;
+    }
+    this.streams.forEach((stream) => {
+      if (stream.ws) {
+        try {
+          stream.ws.removeAllListeners();
+          stream.ws.close();
+        } catch (_) {
+          // ignore
+        }
+      }
+    });
+    this.streams.clear();
+  }
+
+  async refreshSymbols() {
+    try {
+      const top = await this.fetchTopSymbols();
+      const symbols = top.map((item) => item.symbol.toUpperCase());
+      this.symbols = symbols;
+      const currentSet = new Set(symbols);
+
+      // close removed streams
+      this.streams.forEach((_value, symbol) => {
+        if (!currentSet.has(symbol)) {
+          this.teardownStream(symbol);
+        }
+      });
+
+      // start new streams
+      symbols.forEach((symbol, idx) => {
+        const meta = top[idx];
+        if (meta) {
+          const lastPrice = Number(meta.lastPrice);
+          const quoteVolume = Number(meta.quoteVolume);
+          this.symbolMeta.set(symbol, {
+            lastPrice: Number.isFinite(lastPrice) ? lastPrice : null,
+            quoteVolume: Number.isFinite(quoteVolume) ? quoteVolume : null,
+            fetchedAt: Date.now(),
+            rank: idx + 1,
+          });
+        }
+        if (!this.streams.has(symbol)) {
+          this.startStream(symbol);
+        }
+      });
+
+      this.emit('symbols', this.getSymbols());
+    } catch (error) {
+      console.error('[LIQ] Failed to refresh symbols:', error.message);
+    }
+  }
+
+  async fetchTopSymbols() {
+    const response = await fetch(`${BINANCE_FUTURES_API}/fapi/v1/ticker/24hr`);
+    if (!response.ok) {
+      throw new Error(`Ticker request failed: ${response.status}`);
+    }
+    const payload = await response.json();
+    if (!Array.isArray(payload)) {
+      return [];
+    }
+    const filtered = payload
+      .filter((item) => typeof item?.symbol === 'string' && item.symbol.endsWith('USDT'))
+      .map((item) => ({
+        symbol: item.symbol.toUpperCase(),
+        lastPrice: item.lastPrice,
+        priceChangePercent: item.priceChangePercent,
+        quoteVolume: item.quoteVolume,
+      }));
+    filtered.sort((a, b) => {
+      const av = Number(a.quoteVolume) || 0;
+      const bv = Number(b.quoteVolume) || 0;
+      return bv - av;
+    });
+    return filtered.slice(0, this.topSymbols);
+  }
+
+  startStream(symbol) {
+    const lower = symbol.toLowerCase();
+    const url = `${BINANCE_FUTURES_WS}/${lower}@forceOrder`;
+    const stream = {
+      ws: null,
+      retry: 0,
+    };
+    const connect = () => {
+      const ws = new WebSocket(url);
+      stream.ws = ws;
+
+      ws.on('open', () => {
+        stream.retry = 0;
+      });
+
+      ws.on('message', (raw) => {
+        this.handleMessage(symbol, raw);
+      });
+
+      ws.on('error', (err) => {
+        console.error(`[LIQ:${symbol}] WS error:`, err.message);
+      });
+
+      ws.on('close', async () => {
+        const delay = Math.min(60_000, 1000 * 2 ** Math.min(stream.retry, 5));
+        stream.retry += 1;
+        await sleep(delay);
+        if (this.symbols.includes(symbol)) {
+          connect();
+        }
+      });
+    };
+
+    connect();
+    this.streams.set(symbol, stream);
+  }
+
+  teardownStream(symbol) {
+    const stream = this.streams.get(symbol);
+    if (stream && stream.ws) {
+      try {
+        stream.ws.removeAllListeners();
+        stream.ws.close();
+      } catch (_) {
+        // ignore
+      }
+    }
+    this.streams.delete(symbol);
+  }
+
+  handleMessage(symbol, raw) {
+    try {
+      const payload = JSON.parse(raw);
+      const order = payload?.o;
+      if (!order) {
+        return;
+      }
+      const eventTime = Number(order.T || payload.E);
+      const price = Number(order.ap || order.p);
+      const quantity = Number(order.q || order.l || order.z);
+      const side = String(order.S || '');
+      if (!Number.isFinite(eventTime) || !Number.isFinite(price) || !Number.isFinite(quantity) || !side) {
+        return;
+      }
+      const notional = Math.abs(price * quantity);
+      if (!Number.isFinite(notional) || notional <= 0) {
+        return;
+      }
+
+      this.lastPrices.set(symbol, price);
+      const meta = this.symbolMeta.get(symbol) || {};
+      this.symbolMeta.set(symbol, { ...meta, lastPrice: price, updatedAt: Date.now() });
+
+      this.db.run(
+        `INSERT OR IGNORE INTO liquidation_events (symbol, event_time, side, price, quantity, notional)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        [symbol, eventTime, side, price, quantity, notional],
+        (err) => {
+          if (err) {
+            console.error(`[LIQ:${symbol}] Failed to store liquidation event:`, err.message);
+          } else {
+            this.emit('event', { symbol, eventTime, side, price, quantity, notional });
+          }
+        }
+      );
+    } catch (error) {
+      console.error(`[LIQ:${symbol}] Failed to parse message:`, error.message);
+    }
+  }
+
+  pruneOldEvents() {
+    const cutoff = Date.now() - this.retentionDays * 24 * 60 * 60 * 1000;
+    this.db.run(
+      'DELETE FROM liquidation_events WHERE event_time < ?',
+      [cutoff],
+      (err) => {
+        if (err) {
+          console.error('[LIQ] Failed to prune liquidation events:', err.message);
+        }
+      }
+    );
+  }
+
+  getSymbols() {
+    return this.symbols.map((symbol) => {
+      const meta = this.symbolMeta.get(symbol) || {};
+      return {
+        symbol,
+        rank: meta.rank || null,
+        lastPrice: meta.lastPrice ?? null,
+        quoteVolume: meta.quoteVolume ?? null,
+        updatedAt: meta.updatedAt ?? meta.fetchedAt ?? null,
+      };
+    });
+  }
+
+  getLastPrice(symbol) {
+    const meta = this.symbolMeta.get(symbol);
+    if (meta && Number.isFinite(meta.lastPrice)) {
+      return meta.lastPrice;
+    }
+    const last = this.lastPrices.get(symbol);
+    return Number.isFinite(last) ? last : null;
+  }
+
+  getEvents({ symbol, timeframe = '1m', limit = 720 }) {
+    return new Promise((resolve, reject) => {
+      const tf = normalizeTimeframe(timeframe, '1m');
+      const bucketMs = timeframeToMs(tf);
+      if (!bucketMs) {
+        resolve([]);
+        return;
+      }
+      const rangeMs = bucketMs * Math.max(10, limit);
+      const cutoff = Date.now() - rangeMs;
+      this.db.all(
+        `SELECT event_time, side, price, quantity, notional
+         FROM liquidation_events
+         WHERE symbol = ? AND event_time >= ?
+         ORDER BY event_time ASC`,
+        [symbol, cutoff],
+        (err, rows) => {
+          if (err) {
+            reject(err);
+            return;
+          }
+          resolve(rows || []);
+        }
+      );
+    });
+  }
+}
+
+module.exports = {
+  LiquidationHeatmapEngine,
+};


### PR DESCRIPTION
## Summary
- add a liquidation market data engine that streams Binance force-order events, stores them in SQLite, and exposes cached APIs
- wire the liquidation engine into the server lifecycle and export `/api/liquidations` endpoints for symbols and heatmap data
- build a dedicated cosmos dashboard page with styling, ECharts visualisation, and range controls for the liquidation heatmap
- link the new dashboard from the cosmos menu and ignore generated SQLite files

## Testing
- npm start (fails: Binance endpoints unreachable from CI sandbox)


------
https://chatgpt.com/codex/tasks/task_e_68dbe6a79df0832f87a48876b3c153b3