### PR TITLE
feat: migrate market data storage to MongoDB

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "node-fetch": "^2.6.9",
     "mongoose": "^8.6.0",
     "rss-parser": "^3.12.0",
-    "sqlite3": "^5.1.7",
     "ws": "^8.17.0"
   },
   "engines": {

--- a/server/models/marketModels.js
+++ b/server/models/marketModels.js
@@ -1,0 +1,95 @@
+const mongoose = require('mongoose');
+
+const cvdSchema = new mongoose.Schema(
+  {
+    symbol: { type: String, required: true, index: true },
+    tf: { type: String, required: true, index: true },
+    t: { type: Number, required: true, index: true },
+    g0: { type: Number, default: 0 },
+    g1: { type: Number, default: 0 },
+    g2: { type: Number, default: 0 },
+    g3: { type: Number, default: 0 },
+    g4: { type: Number, default: 0 },
+    all: { type: Number, default: 0 },
+    price: { type: Number, default: null },
+  },
+  { timestamps: false, versionKey: false }
+);
+
+cvdSchema.index({ symbol: 1, tf: 1, t: 1 }, { unique: true });
+
+const heatmapLevelSchema = new mongoose.Schema(
+  {
+    binLow: { type: Number, default: null },
+    binHigh: { type: Number, default: null },
+    volUSDT: { type: Number, default: null },
+  },
+  { _id: false }
+);
+
+const heatmapSchema = new mongoose.Schema(
+  {
+    symbol: { type: String, required: true, index: true },
+    tf: { type: String, required: true, index: true },
+    t: { type: Number, required: true, index: true },
+    binLow: { type: Number, default: null },
+    binHigh: { type: Number, default: null },
+    volUSDT: { type: Number, default: null },
+    bids: { type: [[Number]], default: [] },
+    asks: { type: [[Number]], default: [] },
+    lastPrice: { type: Number, default: null },
+    levels: { type: [heatmapLevelSchema], default: undefined },
+  },
+  { timestamps: false, versionKey: false }
+);
+
+heatmapSchema.index({ symbol: 1, tf: 1, t: 1 }, { unique: true });
+
+const priceSchema = new mongoose.Schema(
+  {
+    symbol: { type: String, required: true, index: true },
+    tf: { type: String, required: true, index: true },
+    t: { type: Number, required: true, index: true },
+    close: { type: Number, default: null },
+    volume: { type: Number, default: null },
+  },
+  { timestamps: false, versionKey: false }
+);
+
+priceSchema.index({ symbol: 1, tf: 1, t: 1 }, { unique: true });
+
+const liquidationEventSchema = new mongoose.Schema(
+  {
+    symbol: { type: String, required: true, index: true },
+    eventTime: { type: Number, required: true, index: true },
+    side: { type: String, required: true },
+    price: { type: Number, required: true },
+    quantity: { type: Number, required: true },
+    notional: { type: Number, required: true },
+  },
+  { timestamps: false, versionKey: false }
+);
+
+liquidationEventSchema.index(
+  { symbol: 1, eventTime: 1, side: 1, price: 1, quantity: 1 },
+  { unique: true }
+);
+liquidationEventSchema.index({ symbol: 1, eventTime: -1 });
+liquidationEventSchema.index({ eventTime: -1 });
+
+const CVDModel =
+  mongoose.models.CVD || mongoose.model('CVD', cvdSchema, 'cvd_records');
+const HeatmapModel =
+  mongoose.models.Heatmap || mongoose.model('Heatmap', heatmapSchema, 'heatmap_records');
+const PriceModel =
+  mongoose.models.Price || mongoose.model('Price', priceSchema, 'price_records');
+const LiquidationEventModel =
+  mongoose.models.LiquidationEvent ||
+  mongoose.model('LiquidationEvent', liquidationEventSchema, 'liquidation_events');
+
+module.exports = {
+  CVDModel,
+  HeatmapModel,
+  PriceModel,
+  LiquidationEventModel,
+};


### PR DESCRIPTION
## Summary
- connect the application to MongoDB via a shared database helper and remove the old SQLite dependency
- define reusable Mongoose models for CVD, heatmap, price, and liquidation data
- refactor engines and API routes to read and write through the Mongo-backed models and keep Atlas data persistent

## Testing
- not run (MongoDB connection string required)


------
https://chatgpt.com/codex/tasks/task_e_68dbef5094d4832f94ea609b9a280745