### PR TITLE
Fix liquidation event payload redeclaration and add lint step

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,38 @@
+const commonRules = {
+  'no-redeclare': 'error',
+};
+
+module.exports = [
+  {
+    files: ['**/*.js'],
+    ignores: ['node_modules/**'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'commonjs',
+      globals: {
+        Buffer: 'readonly',
+        __dirname: 'readonly',
+        clearImmediate: 'readonly',
+        clearInterval: 'readonly',
+        clearTimeout: 'readonly',
+        console: 'readonly',
+        exports: 'readonly',
+        module: 'readonly',
+        process: 'readonly',
+        require: 'readonly',
+        setImmediate: 'readonly',
+        setInterval: 'readonly',
+        setTimeout: 'readonly',
+      },
+    },
+    rules: commonRules,
+  },
+  {
+    files: ['apps/**/*.js'],
+    languageOptions: {
+      ecmaVersion: 2021,
+      sourceType: 'module',
+    },
+    rules: commonRules,
+  },
+];

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "version": "1.0.0",
   "main": "server.js",
   "scripts": {
-    "start": "node server.js"
+    "start": "node server.js",
+    "lint": "npx eslint ."
   },
   "dependencies": {
     "express": "^4.18.2",
@@ -12,6 +13,9 @@
     "mongoose": "^8.6.0",
     "rss-parser": "^3.12.0",
     "ws": "^8.17.0"
+  },
+  "devDependencies": {
+    "eslint": "^9.0.0"
   },
   "engines": {
     "node": "18.x"

--- a/server/engines/liquidationHeatmapEngine.js
+++ b/server/engines/liquidationHeatmapEngine.js
@@ -193,20 +193,20 @@ class LiquidationHeatmapEngine extends EventEmitter {
       const meta = this.symbolMeta.get(symbol) || {};
       this.symbolMeta.set(symbol, { ...meta, lastPrice: price, updatedAt: Date.now() });
 
-      const payload = { symbol, eventTime, side, price, quantity, notional };
+      const eventPayload = { symbol, eventTime, side, price, quantity, notional };
       if (!this.liquidationModel) {
-        this.emit('event', payload);
+        this.emit('event', eventPayload);
         return;
       }
 
       this.liquidationModel
         .updateOne(
           { symbol, eventTime, side, price, quantity },
-          { $setOnInsert: payload },
+          { $setOnInsert: eventPayload },
           { upsert: true }
         )
         .then(() => {
-          this.emit('event', payload);
+          this.emit('event', eventPayload);
         })
         .catch((error) => {
           console.error(`[LIQ:${symbol}] Failed to store liquidation event:`, error.message);


### PR DESCRIPTION
## Summary
- rename the duplicated liquidation stream payload to avoid redeclaration errors
- add an ESLint flat config that enforces the no-redeclare rule across the project
- wire up an npm lint script using ESLint

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68dbf6593ff0832f950858f0354b022b