### PR TITLE
Add fallback liquidation heatmap API when MongoDB is unavailable

### DIFF
--- a/apps/web/menu/cosmos/liquidation-heatmap.js
+++ b/apps/web/menu/cosmos/liquidation-heatmap.js
@@ -257,7 +257,11 @@
         updatedEl.textContent = '--';
       }
     }
-    setStatus('Online', 'online');
+    if (payload?.meta?.disabled) {
+      setStatus('Offline', 'error');
+    } else {
+      setStatus('Online', 'online');
+    }
   }
 
   function render(payload) {


### PR DESCRIPTION
## Summary
- add a disabled liquidation heatmap router so the API returns structured empty data when MongoDB is missing
- surface the disabled state on the liquidation heatmap page so the status pill shows the feature is offline

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de4feb6d1c832fb7378fcade77910d