### PR TITLE
Add CoinGecko fallback for cosmos chart

### DIFF
--- a/apps/web/menu/cosmos/chart.html
+++ b/apps/web/menu/cosmos/chart.html
@@ -103,6 +103,7 @@ if(!s){
 }
 const SYMBOL=(s||'BTCUSDT').toUpperCase();
 let TF=(qs.get('tf')||qs.get('interval')||'15m').toLowerCase();
+const ID_HINT=(qs.get('id')||'').toLowerCase();
 
 /* ===== Fetch 도우미 (직접 → 프록시) ===== */
 async function getJson(direct, proxy){
@@ -138,6 +139,182 @@ function oiURL(sym,period='5m',limit=600){
 /* ===== 변환기 ===== */
 const toCandle = k => ({ time:Number(k[0]), open:+k[1], high:+k[2], low:+k[3], close:+k[4] });
 const toVolume = k => ({ time:Number(k[0]), value:+k[5], color:(+k[4] >= +k[1]) ? 'rgba(34,197,94,.55)' : 'rgba(239,68,68,.55)' });
+
+const CG_SYMBOL_MAP={
+  BTC:'bitcoin',BTCUSDT:'bitcoin',BTCUSD:'bitcoin',
+  ETH:'ethereum',ETHUSDT:'ethereum',
+  SOL:'solana',SOLUSDT:'solana',
+  BNB:'binancecoin',BNBUSDT:'binancecoin',
+  XRP:'ripple',XRPUSDT:'ripple',
+  ADA:'cardano',ADAUSDT:'cardano',
+  DOGE:'dogecoin',DOGEUSDT:'dogecoin',
+  AVAX:'avalanche-2',AVAXUSDT:'avalanche-2',
+  TRX:'tron',TRXUSDT:'tron',
+  TON:'the-open-network',TONUSDT:'the-open-network',
+  MATIC:'matic-network',MATICUSDT:'matic-network',
+  DOT:'polkadot',DOTUSDT:'polkadot',
+  LINK:'chainlink',LINKUSDT:'chainlink',
+  LTC:'litecoin',LTCUSDT:'litecoin',
+  OP:'optimism',OPUSDT:'optimism',
+  ARB:'arbitrum',ARBUSDT:'arbitrum'
+};
+
+function guessCoinGeckoId(symbol){
+  if(!symbol) return ID_HINT || '';
+  const upper=symbol.toUpperCase();
+  if(CG_SYMBOL_MAP[upper]) return CG_SYMBOL_MAP[upper];
+  const base=upper.replace(/[-_]/g,'').replace(/(USDT|USDC|USD|BUSD|PERP)$/,'');
+  if(CG_SYMBOL_MAP[base]) return CG_SYMBOL_MAP[base];
+  return ID_HINT || base.toLowerCase();
+}
+
+function normalizeTimeline(baseRows, step, limit){
+  if(!Array.isArray(baseRows) || !baseRows.length || !Number.isFinite(step)) return [];
+  const rows=baseRows
+    .filter(row=>Array.isArray(row) && row.length>=5)
+    .map(row=>[
+      Math.floor(Number(row[0])),
+      Number(row[1]),
+      Number(row[2]),
+      Number(row[3]),
+      Number(row[4]),
+      Number(row[5] ?? 0)
+    ])
+    .filter(row=>row.every((v)=>Number.isFinite(v)));
+
+  rows.sort((a,b)=>a[0]-b[0]);
+  if(!rows.length) return [];
+
+  const norm=[];
+  for(let i=0;i<rows.length;i++){
+    const cur=rows[i];
+    norm.push(cur);
+    if(i+1<rows.length){
+      const nextTime=rows[i+1][0];
+      const gapCount=Math.floor((nextTime-cur[0])/step)-1;
+      if(gapCount>0 && gapCount<=3){
+        for(let u=cur[0]+step; u<nextTime; u+=step){
+          const prevClose=cur[4];
+          norm.push([u,prevClose,prevClose,prevClose,prevClose,0]);
+        }
+      }
+    }
+  }
+
+  const now=Math.floor(Date.now()/1000);
+  let last=norm[norm.length-1];
+  while(last && last[0]+step<=now && (!limit || norm.length<limit+20)){
+    const prevClose=last[4];
+    last=[last[0]+step,prevClose,prevClose,prevClose,prevClose,0];
+    norm.push(last);
+  }
+
+  if(limit && norm.length>limit){
+    norm.splice(0, norm.length-limit);
+  }
+
+  return norm;
+}
+
+async function fetchBinanceRows(symbol, tf){
+  const limit=chooseLimit(tf);
+  const [directUrl, proxyUrl]=klineURL(symbol, tf, limit);
+  let rows=await getJson(directUrl, proxyUrl);
+  if(rows && Array.isArray(rows.data)) rows=rows.data;
+  if(!Array.isArray(rows)) throw new Error('invalid klines payload');
+  if(!rows.length) return [];
+
+  const step=TFSEC[tf] ?? 60;
+  const snapMap=new Map();
+  const normalizeTs=(val)=>{
+    const num=Number(val);
+    if(!Number.isFinite(num)) return null;
+    return num>1e12 ? Math.floor(num/1000) : Math.floor(num);
+  };
+
+  for(const entry of rows){
+    const ts=normalizeTs(entry?.[0]);
+    if(!Number.isFinite(ts)) continue;
+    const snapped=Math.floor(ts/step)*step;
+    const norm=[
+      snapped,
+      Number(entry?.[1])||0,
+      Number(entry?.[2])||Number(entry?.[1])||0,
+      Number(entry?.[3])||Number(entry?.[1])||0,
+      Number(entry?.[4])||Number(entry?.[1])||0,
+      Number(entry?.[5])||0
+    ];
+    snapMap.set(snapped,norm);
+  }
+
+  const values=Array.from(snapMap.values());
+  return normalizeTimeline(values, step, limit);
+}
+
+async function fetchCoinGeckoRows(symbol, tf){
+  const id=guessCoinGeckoId(symbol);
+  if(!id) throw new Error('unable to resolve CoinGecko id');
+  const step=TFSEC[tf] ?? 60;
+  const limit=chooseLimit(tf);
+  const nowSec=Math.floor(Date.now()/1000);
+  const span=step*(limit+Math.min(limit,240));
+  const fromSec=Math.max(0, nowSec-span);
+  const url=`https://api.coingecko.com/api/v3/coins/${encodeURIComponent(id)}/market_chart/range?vs_currency=usd&from=${fromSec}&to=${nowSec}`;
+
+  const res=await fetch(url);
+  if(!res.ok) throw new Error(`coingecko http ${res.status}`);
+  const data=await res.json();
+  const priceArr=Array.isArray(data?.prices)?data.prices:[];
+  if(!priceArr.length) throw new Error('coingecko prices empty');
+
+  const buckets=new Map();
+  for(const entry of priceArr){
+    if(!Array.isArray(entry)||entry.length<2) continue;
+    const ts=Math.floor(Number(entry[0])/1000);
+    const price=Number(entry[1]);
+    if(!Number.isFinite(ts)||!Number.isFinite(price)) continue;
+    const bucketTime=Math.floor(ts/step)*step;
+    let bucket=buckets.get(bucketTime);
+    if(!bucket){
+      bucket={ time:bucketTime, open:price, high:price, low:price, close:price, first:ts, last:ts, volume:0 };
+      buckets.set(bucketTime,bucket);
+    }else{
+      if(ts<bucket.first){ bucket.first=ts; bucket.open=price; }
+      if(ts>=bucket.last){ bucket.last=ts; bucket.close=price; }
+      if(price>bucket.high) bucket.high=price;
+      if(price<bucket.low) bucket.low=price;
+    }
+  }
+
+  const volumes=Array.isArray(data?.total_volumes)?data.total_volumes:[];
+  for(let i=1;i<volumes.length;i++){
+    const prev=volumes[i-1];
+    const cur=volumes[i];
+    if(!Array.isArray(prev)||!Array.isArray(cur)) continue;
+    const curTs=Math.floor(Number(cur[0])/1000);
+    const delta=Number(cur[1])-Number(prev[1]);
+    if(!Number.isFinite(curTs)||!Number.isFinite(delta)) continue;
+    const bucketTime=Math.floor(curTs/step)*step;
+    const bucket=buckets.get(bucketTime);
+    if(bucket) bucket.volume += Math.max(0, delta);
+  }
+
+  const baseRows=[];
+  const times=Array.from(buckets.keys()).sort((a,b)=>a-b);
+  let prevClose=null;
+  for(const t of times){
+    const bucket=buckets.get(t);
+    const open=Number.isFinite(bucket.open)?bucket.open:(prevClose??0);
+    const close=Number.isFinite(bucket.close)?bucket.close:open;
+    const high=Number.isFinite(bucket.high)?bucket.high:Math.max(open,close);
+    const low=Number.isFinite(bucket.low)?bucket.low:Math.min(open,close);
+    const vol=Number(bucket.volume)||0;
+    baseRows.push([t,open,high,low,close,vol]);
+    prevClose=close;
+  }
+
+  return normalizeTimeline(baseRows, step, limit);
+}
 
 /* ===== 수학: WMA/HMA & SMA/STD & BB & RSI ===== */
 function wma(values, period){
@@ -326,164 +503,111 @@ function clearAllSeries(){
 async function loadAll(){
   syncTFUI();
   showStatus('Loading...', 'muted');
-  const [dURL,pURL] = klineURL(SYMBOL, TF, chooseLimit(TF));
-  try {
-    let rows = await getJson(dURL,pURL);           // 바이낸스 klines 원본(배열[])
+  let rowsNorm=[];
+  let usingFallback=false;
+  let binanceError=null;
 
-    if (rows && Array.isArray(rows.data)) rows = rows.data;
-    if (!Array.isArray(rows)) {
-      throw new Error('invalid klines payload');
+  try{
+    try{
+      rowsNorm = await fetchBinanceRows(SYMBOL, TF);
+    }catch(err){
+      binanceError = err;
+      console.warn('[chart] binance fetch failed:', err?.message || err);
     }
 
-    if (!rows.length) {
+    if(!rowsNorm || !rowsNorm.length){
+      try{
+        showStatus('CoinGecko 데이터로 대체 로딩 중…', 'muted');
+        rowsNorm = await fetchCoinGeckoRows(SYMBOL, TF);
+        usingFallback = true;
+      }catch(fallbackErr){
+        console.error('chart load failed', fallbackErr);
+        if(binanceError) console.error('primary binance error:', binanceError);
+        clearAllSeries();
+        showStatus('차트를 불러오지 못했습니다', 'error');
+        return;
+      }
+    }
+
+    if(!rowsNorm || !rowsNorm.length){
       clearAllSeries();
       showStatus('데이터가 없습니다', 'muted');
       return;
     }
 
-  // === Binance klines 정규화: ms→sec, 경계 스냅, 중복제거, 결측 채움 ===
-  const SEC_OF = { '1m':60,'5m':300,'15m':900,'30m':1800,'1h':3600,'4h':14400,'1d':86400,'1w':604800 };
+    const candles = rowsNorm.map(toCandle);
+    const volumes = rowsNorm.map(toVolume);
+    mainSeries.setData(candles);
+    volSeries.setData(volumes);
+    chart.timeScale().fitContent();
 
-  // 1) 응답 형태 통일 (프록시가 {timestamp,price}일 때 배열형으로 맞춤)
-  if (rows?.length) {
-    if (!Array.isArray(rows[0]) && rows[0]?.timestamp != null) {
-      rows = rows.map(r => [Number(r.timestamp), String(r.price), String(r.price), String(r.price), String(r.price), "0"]);
+    if(usingFallback){
+      console.info('[chart] CoinGecko fallback active for', SYMBOL, TF);
     }
-    // 시간 오름차순
-    rows.sort((a,b) => Number(a[0]) - Number(b[0]));
-    // 13자리(ms)면 초로 1번만 변환
-    if (Number(rows[0][0]) > 1e12) {
-      for (let i=0;i<rows.length;i++) rows[i][0] = Math.floor(Number(rows[i][0]) / 1000);
+
+    const steps = [...new Set(candles.slice(1).map((b,i)=>candles[i+1].time - candles[i].time))];
+    console.log('uniq steps:', steps);
+
+    const firstCandle = candles[0];
+    const lastCandle = lastItem(candles);
+    if (firstCandle && lastCandle) {
+      console.log('[candles]', TF, candles.length, 'from', new Date(firstCandle.time*1000).toISOString(), 'to', new Date(lastCandle.time*1000).toISOString());
     }
-  }
+    for(let i=1;i<Math.min(candles.length,50);i++){
+      const d=candles[i].time - candles[i-1].time;
+      if(d !== TFSEC[TF]){ console.warn('STEP MISMATCH at', i, 'Δ', d); break; }
+    }
 
-  // 2) 간격 경계에 스냅 - UTC 기준으로 처리
-  const STEP = SEC_OF[TF] ?? 60;
-  const snap = t => Math.floor(Number(t) / STEP) * STEP;
-  const snapMap = new Map(); // t -> [t, open, high, low, close, vol]
+    const last = lastCandle;
+    const prev = nthFromEnd(candles, 1) || last;
+    const lastPrice = last?.close ?? 0;
+    const prevClose = prev?.close ?? lastPrice;
+    if (!last || !Number.isFinite(lastPrice) || !Number.isFinite(prevClose)) {
+      showStatus('가격 데이터를 불러오지 못했습니다', 'error');
+      return;
+    }
+    const pct = prevClose !== 0 ? ((lastPrice - prevClose)/prevClose)*100 : 0;
+    document.getElementById('lastPrice').textContent = lastPrice.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});
+    const chg = document.getElementById('pctChg');
+    chg.textContent = (pct>=0?'+':'') + pct.toFixed(2) + '%';
+    chg.className = 'chg ' + (pct>=0?'up':'down');
 
-  // 같은 버킷(t)에서 최신 값만 남김
-  for (const k of rows) {
-    const t = snap(k[0]);
-    const v = [t, +k[1], +k[2], +k[3], +k[4], +k[5] || 0];
-    snapMap.set(t, v);
-  }
+    const rtime = rowsNorm.map(r => Number(r[0]));
+    const closes = candles.map(c=>c.close);
 
-  // 3) 결측 구간 채우기 - 제한된 범위만
-  const ts = [...snapMap.keys()].sort((a,b)=>a-b);
-  const norm = [];
-  for (let i=0;i<ts.length;i++) {
-    const t = ts[i];
-    const cur = snapMap.get(t);
-    norm.push(cur);
-    if (i+1 < ts.length) {
-      let nxt = ts[i+1];
-      let gapCount = Math.floor((nxt - t) / STEP) - 1;
-      
-      // 결측 구간이 3개 이하일 때만 채움 (과도한 가상 캔들 생성 방지)
-      if (gapCount > 0 && gapCount <= 3) {
-        for (let u = t + STEP; u < nxt; u += STEP) {
-          const prevClose = cur[4];
-          norm.push([u, prevClose, prevClose, prevClose, prevClose, 0]);
-        }
+    const h50v  = hma(closes,50).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
+    const h100v = hma(closes,100).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
+    const h200v = hma(closes,200).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
+    h50.setData(h50v); h100.setData(h100v); h200.setData(h200v);
+
+    (function(){
+      const len=14, out=[];
+      let avgG=0, avgL=0;
+      for(let i=1;i<closes.length;i++){
+        const ch=closes[i]-closes[i-1], g=Math.max(ch,0), l=Math.max(-ch,0);
+        if(i<=len){ avgG+=g; avgL+=l; if(i===len){ avgG/=len; avgL/=len; const rs=avgL===0?100:avgG/avgL; out.push({time:rtime[i], value:100-(100/(1+rs))}); } }
+        else{ avgG=(avgG*(len-1)+g)/len; avgL=(avgL*(len-1)+l)/len; const rs=avgL===0?100:avgG/avgL; out.push({time:rtime[i], value:100-(100/(1+rs))}); }
       }
-    }
-  }
+      rsiPane.setData(out);
+    })();
 
-  // 3-1) 마지막 캔들 이후 현재 시점까지 더미 캔들 보강
-  const now = Math.floor(Date.now() / 1000);
-  let last = lastItem(norm);
-  while (last && last[0] + STEP <= now) {
-    const prevClose = last[4];
-    last = [last[0] + STEP, prevClose, prevClose, prevClose, prevClose, 0];
-    norm.push(last);
-  }
+    const bb = calcBB(closes, 20, 2);
+    bbUpper.setData(bb.upper.map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
+    bbMid  .setData(bb.mid  .map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
+    bbLower.setData(bb.lower.map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
 
-  // 이후 로직은 norm 사용
-  const rowsNorm = norm;
+    try{
+      const period = (TF.endsWith('m') ? TF : '5m');
+      const [od,op] = oiURL(SYMBOL, period, 600);
+      const oij = await getJson(od,op);
+      const oiData = oij.map(x=>({ time: Math.floor(new Date(x.timestamp).getTime()/1000), value: +x.sumOpenInterest }));
+      oiPane.setData(oiData);
+    }catch(e){ oiPane.setData([]); }
 
-  if (!rowsNorm.length) {
-    clearAllSeries();
-    showStatus('데이터가 없습니다', 'muted');
-    return;
-  }
-
-  const candles = rowsNorm.map(toCandle);
-  const volumes = rowsNorm.map(toVolume);
-  mainSeries.setData(candles);
-  volSeries.setData(volumes);
-  chart.timeScale().fitContent();
-
-  // 디버그: 타임 스텝 확인
-  const steps = [...new Set(candles.slice(1).map((b,i)=>candles[i+1].time - candles[i].time))];
-  console.log('uniq steps:', steps);
-
-  // 디버그: 렌더에 넣은 데이터 확인
-  const firstCandle = candles[0];
-  const lastCandle = lastItem(candles);
-  if (firstCandle && lastCandle) {
-    console.log('[candles]', TF, candles.length, 'from', new Date(firstCandle.time*1000).toISOString(), 'to', new Date(lastCandle.time*1000).toISOString());
-  }
-  for(let i=1;i<Math.min(candles.length,50);i++){
-    const d=candles[i].time - candles[i-1].time;
-    if(d !== TFSEC[TF]){ console.warn('STEP MISMATCH at', i, 'Δ', d); break; }
-  }
-
-  // 가격/등락 표시
-  const last = lastCandle;
-  const prev = nthFromEnd(candles, 1) || last;
-  const lastPrice = last?.close ?? 0;
-  const prevClose = prev?.close ?? lastPrice;
-  if (!last || !Number.isFinite(lastPrice) || !Number.isFinite(prevClose)) {
-    showStatus('가격 데이터를 불러오지 못했습니다', 'error');
-    return;
-  }
-  const pct = prevClose !== 0 ? ((lastPrice - prevClose)/prevClose)*100 : 0;
-  document.getElementById('lastPrice').textContent = lastPrice.toLocaleString('en-US',{minimumFractionDigits:2,maximumFractionDigits:2});
-  const chg = document.getElementById('pctChg');
-  chg.textContent = (pct>=0?'+':'') + pct.toFixed(2) + '%';
-  chg.className = 'chg ' + (pct>=0?'up':'down');
-
-  // 보조지표 계산은 보정된 타임라인 기준
-  const rtime = rowsNorm.map(r => Number(r[0]));
-  const closes = candles.map(c=>c.close);
-
-  // HMA
-  const h50v  = hma(closes,50).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
-  const h100v = hma(closes,100).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
-  const h200v = hma(closes,200).map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean);
-  h50.setData(h50v); h100.setData(h100v); h200.setData(h200v);
-
-  // RSI(14)
-  (function(){
-    const len=14, out=[];
-    let avgG=0, avgL=0;
-    for(let i=1;i<closes.length;i++){
-      const ch=closes[i]-closes[i-1], g=Math.max(ch,0), l=Math.max(-ch,0);
-      if(i<=len){ avgG+=g; avgL+=l; if(i===len){ avgG/=len; avgL/=len; const rs=avgL===0?100:avgG/avgL; out.push({time:rtime[i], value:100-(100/(1+rs))}); } }
-      else{ avgG=(avgG*(len-1)+g)/len; avgL=(avgL*(len-1)+l)/len; const rs=avgL===0?100:avgG/avgL; out.push({time:rtime[i], value:100-(100/(1+rs))}); }
-    }
-    rsiPane.setData(out);
-  })();
-
-  // BB(20, 2σ)
-  const bb = calcBB(closes, 20, 2);
-  bbUpper.setData(bb.upper.map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
-  bbMid  .setData(bb.mid  .map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
-  bbLower.setData(bb.lower.map((v,i)=>v==null?null:{time:rtime[i], value:v}).filter(Boolean));
-
-  // OI (근사 period)
-  try{
-    const period = (TF.endsWith('m') ? TF : '5m');
-    const [od,op] = oiURL(SYMBOL, period, 600);
-    const oij = await getJson(od,op);
-    const oiData = oij.map(x=>({ time: Math.floor(new Date(x.timestamp).getTime()/1000), value: +x.sumOpenInterest }));
-    oiPane.setData(oiData);
-  }catch(e){ oiPane.setData([]); }
-
-  hideStatus();
-  } catch (err) {
+    hideStatus();
+  }catch(err){
     console.error('chart load failed', err);
+    if(binanceError) console.error('primary binance error:', binanceError);
     clearAllSeries();
     showStatus('차트를 불러오지 못했습니다', 'error');
   }


### PR DESCRIPTION
## Summary
- add a CoinGecko-backed fallback when Binance klines are unavailable on the cosmos chart
- introduce shared helpers to normalize candle timelines and resolve CoinGecko ids for popular symbols
- refactor the loader to reuse the helpers, preserve indicator updates, and surface fallback status messaging

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68de537eb828832f90825c964a4a4ae2