### PR TITLE
Add FVG and order block overlays to liquidation heatmap

### DIFF
--- a/apps/web/menu/cosmos/liquidation-heatmap.css
+++ b/apps/web/menu/cosmos/liquidation-heatmap.css
@@ -296,6 +296,118 @@ body {
   height: clamp(420px, 60vh, 620px);
 }
 
+.chart .overlay-chart {
+  position: absolute;
+  inset: 24px 80px 40px 60px;
+  pointer-events: none;
+  border-radius: 12px;
+  overflow: hidden;
+  z-index: 3;
+}
+
+.chart .overlay-chart canvas {
+  pointer-events: none !important;
+}
+
+.overlay-primitives {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  font-family: var(--font-heading);
+}
+
+.fvg-box,
+.ob-box {
+  position: absolute;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  box-shadow: 0 0 18px rgba(25, 10, 60, 0.45);
+  pointer-events: none;
+  overflow: hidden;
+  backdrop-filter: blur(2px);
+}
+
+.fvg-box {
+  display: flex;
+  align-items: flex-end;
+  padding: 6px;
+}
+
+.fvg-box.bullish {
+  border-color: rgba(0, 255, 196, 0.55);
+  background: linear-gradient(180deg, rgba(0, 255, 196, 0.18), rgba(0, 120, 96, 0.05));
+}
+
+.fvg-box.bearish {
+  border-color: rgba(255, 70, 166, 0.55);
+  background: linear-gradient(180deg, rgba(255, 70, 166, 0.18), rgba(120, 0, 80, 0.05));
+}
+
+.fvg-volume-bar {
+  display: flex;
+  align-items: stretch;
+  justify-content: stretch;
+  width: 100%;
+  min-height: 18px;
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+  background: rgba(6, 10, 20, 0.35);
+}
+
+.fvg-volume-bar span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.68rem;
+  letter-spacing: 0.06em;
+  color: #0e0c1f;
+  text-shadow: none;
+  padding: 0 4px;
+}
+
+.fvg-volume-bar .bull {
+  background: linear-gradient(90deg, rgba(0, 255, 188, 0.75), rgba(0, 200, 220, 0.65));
+}
+
+.fvg-volume-bar .bear {
+  background: linear-gradient(90deg, rgba(255, 70, 166, 0.75), rgba(255, 120, 200, 0.65));
+}
+
+.fvg-volume-bar .empty {
+  background: rgba(18, 12, 40, 0.45);
+  color: rgba(255, 255, 255, 0.45);
+}
+
+.ob-box {
+  border-style: dashed;
+  padding: 6px 8px;
+  display: flex;
+  align-items: flex-start;
+}
+
+.ob-box.bullish {
+  border-color: rgba(0, 214, 255, 0.6);
+  background: rgba(0, 214, 255, 0.08);
+}
+
+.ob-box.bearish {
+  border-color: rgba(255, 120, 220, 0.6);
+  background: rgba(255, 120, 220, 0.08);
+}
+
+.ob-label {
+  font-size: 0.72rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(241, 245, 255, 0.92);
+  text-shadow: 0 0 8px rgba(0, 255, 196, 0.35);
+}
+
+.ob-box.bearish .ob-label {
+  text-shadow: 0 0 8px rgba(255, 120, 220, 0.35);
+}
+
 .empty-state {
   text-align: center;
   padding: 24px;

--- a/apps/web/menu/cosmos/liquidation-heatmap.html
+++ b/apps/web/menu/cosmos/liquidation-heatmap.html
@@ -82,10 +82,12 @@
   </main>
 
   <footer class="page-footer">
-    Data sourced from Binance Futures force-order streams · 저장소: SQLite · 업데이트 간격: 실시간
+    Data sourced from Binance Futures force-order streams · 저장소: SQLite · 업데이트 간격: 실시간<br />
+    Inspired by “Volumatic Fair Value Gaps [BigBeluga]” — CC BY-NC-SA 4.0
   </footer>
 
   <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js" defer></script>
+  <script src="https://unpkg.com/lightweight-charts@4.1.1/dist/lightweight-charts.standalone.production.js" defer></script>
   <script src="./liquidation-heatmap.js" defer></script>
 </body>
 </html>

--- a/apps/web/menu/cosmos/liquidation-heatmap.js
+++ b/apps/web/menu/cosmos/liquidation-heatmap.js
@@ -6,6 +6,14 @@
     '1w': { tf: '15m', limit: 672 },
     '2w': { tf: '1h', limit: 336 },
   };
+  const TIMEFRAME_TO_MS = {
+    '1m': 60_000,
+    '3m': 180_000,
+    '5m': 300_000,
+    '15m': 900_000,
+    '30m': 1_800_000,
+    '1h': 3_600_000,
+  };
   const symbolInput = document.getElementById('symbolInput');
   const symbolList = document.getElementById('symbolList');
   const buttons = Array.from(document.querySelectorAll('.range-button'));
@@ -22,6 +30,31 @@
     console.warn('[LiqHeatmap] Missing required elements.');
     return;
   }
+
+  const overlayState = {
+    container: null,
+    chart: null,
+    series: null,
+    shapesRoot: null,
+    candles: [],
+    fvgs: [],
+    obs: [],
+    bucketMs: 60_000,
+    volumeBuckets: new Map(),
+  };
+  let overlayRaf = null;
+  let overlayObserver = null;
+
+  const overlayContainer = document.createElement('div');
+  overlayContainer.className = 'overlay-chart';
+  const overlayShapes = document.createElement('div');
+  overlayShapes.className = 'overlay-primitives';
+  overlayContainer.appendChild(overlayShapes);
+  chartEl.appendChild(overlayContainer);
+  overlayState.container = overlayContainer;
+  overlayState.shapesRoot = overlayShapes;
+
+  initOverlayChart();
 
   const chart = echarts.init(chartEl);
   const numberFormatter = new Intl.NumberFormat('en-US');
@@ -41,6 +74,10 @@
     loading: false,
     abortController: null,
   };
+
+  function timeframeToMs(tf) {
+    return TIMEFRAME_TO_MS[tf] || 60_000;
+  }
 
   function formatNotional(value) {
     if (!Number.isFinite(value)) {
@@ -98,12 +135,506 @@
     });
   }
 
+  function clearOverlay() {
+    if (overlayState.series) {
+      try {
+        overlayState.series.setData([]);
+      } catch (_) {
+        // ignore rendering errors during disposal
+      }
+    }
+    overlayState.candles = [];
+    overlayState.fvgs = [];
+    overlayState.obs = [];
+    overlayState.volumeBuckets = new Map();
+    if (overlayState.shapesRoot) {
+      overlayState.shapesRoot.innerHTML = '';
+    }
+  }
+
   function setEmptyVisible(visible) {
     if (!emptyState) return;
     emptyState.hidden = !visible;
     if (visible) {
       chart.clear();
+      clearOverlay();
     }
+  }
+
+  function initOverlayChart(retry = 0) {
+    if (!overlayState.container) {
+      return;
+    }
+    if (overlayState.chart) {
+      return;
+    }
+    const LW = window.LightweightCharts;
+    if (!LW || typeof LW.createChart !== 'function') {
+      if (retry < 6) {
+        setTimeout(() => initOverlayChart(retry + 1), 500);
+      } else {
+        console.warn('[LiqHeatmap] LightweightCharts unavailable. Overlay disabled.');
+      }
+      return;
+    }
+    overlayState.chart = LW.createChart(overlayState.container, {
+      layout: {
+        background: { type: 'solid', color: 'transparent' },
+        textColor: '#e8f3ff',
+        fontFamily: "'Rajdhani', sans-serif",
+      },
+      grid: { vertLines: { visible: false }, horzLines: { visible: false } },
+      rightPriceScale: { visible: false },
+      leftPriceScale: { visible: false },
+      timeScale: {
+        visible: false,
+        secondsVisible: true,
+        timeVisible: true,
+        fixLeftEdge: true,
+        fixRightEdge: true,
+      },
+      crosshair: { mode: LW.CrosshairMode.Hidden },
+      handleScroll: false,
+      handleScale: false,
+    });
+    overlayState.series = overlayState.chart.addCandlestickSeries({
+      upColor: '#4cf0ff',
+      downColor: '#ff47c4',
+      wickUpColor: '#4cf0ff',
+      wickDownColor: '#ff47c4',
+      borderVisible: false,
+      priceLineVisible: false,
+      lastValueVisible: false,
+    });
+    overlayState.chart.timeScale().fitContent();
+    if (overlayState.candles.length) {
+      try {
+        overlayState.series.setData(overlayState.candles);
+        overlayState.chart.timeScale().fitContent();
+      } catch (error) {
+        console.warn('[LiqHeatmap] Deferred overlay sync failed:', error);
+      }
+      scheduleOverlayRender();
+    }
+
+    if (typeof ResizeObserver !== 'undefined') {
+      overlayObserver = new ResizeObserver(() => {
+        if (!overlayState.container || !overlayState.chart) {
+          return;
+        }
+        const rect = overlayState.container.getBoundingClientRect();
+        overlayState.chart.resize(rect.width, rect.height);
+        scheduleOverlayRender();
+      });
+      overlayObserver.observe(overlayState.container);
+    } else {
+      window.addEventListener('resize', scheduleOverlayRender);
+    }
+  }
+
+  function scheduleOverlayRender() {
+    if (overlayRaf) {
+      cancelAnimationFrame(overlayRaf);
+    }
+    overlayRaf = requestAnimationFrame(() => {
+      overlayRaf = null;
+      renderOverlayPrimitives();
+    });
+  }
+
+  function buildVolumeBuckets(payload) {
+    const buckets = new Map();
+    const longs = Array.isArray(payload?.longSeries) ? payload.longSeries : [];
+    const shorts = Array.isArray(payload?.shortSeries) ? payload.shortSeries : [];
+    longs.forEach((row) => {
+      const ts = Number(row?.[0]);
+      const value = Number(row?.[1]);
+      if (!Number.isFinite(ts) || !Number.isFinite(value)) {
+        return;
+      }
+      const entry = buckets.get(ts) || { long: 0, short: 0 };
+      entry.long += value;
+      buckets.set(ts, entry);
+    });
+    shorts.forEach((row) => {
+      const ts = Number(row?.[0]);
+      const value = Number(row?.[1]);
+      if (!Number.isFinite(ts) || !Number.isFinite(value)) {
+        return;
+      }
+      const entry = buckets.get(ts) || { long: 0, short: 0 };
+      entry.short += value;
+      buckets.set(ts, entry);
+    });
+    return buckets;
+  }
+
+  function computeFvgVolume(fvg) {
+    if (!fvg || !overlayState.candles.length || !overlayState.bucketMs) {
+      return { bullish: 0, bearish: 0, long: 0, short: 0 };
+    }
+    const buckets = overlayState.volumeBuckets;
+    if (!(buckets instanceof Map) || buckets.size === 0) {
+      return { bullish: 0, bearish: 0, long: 0, short: 0 };
+    }
+    const used = new Set();
+    let totalLong = 0;
+    let totalShort = 0;
+    for (let idx = fvg.startIndex; idx <= fvg.endIndex && idx < overlayState.candles.length; idx += 1) {
+      const candle = overlayState.candles[idx];
+      if (!candle) {
+        continue;
+      }
+      const key = Math.floor((candle.time * 1000) / overlayState.bucketMs) * overlayState.bucketMs;
+      if (used.has(key)) {
+        continue;
+      }
+      used.add(key);
+      const entry = buckets.get(key);
+      if (entry) {
+        totalLong += Number(entry.long) || 0;
+        totalShort += Number(entry.short) || 0;
+      }
+    }
+    const total = totalLong + totalShort;
+    const bullish = total > 0 ? (totalShort / total) * 100 : 0;
+    const bearish = total > 0 ? (totalLong / total) * 100 : 0;
+    return { bullish, bearish, long: totalLong, short: totalShort };
+  }
+
+  function detectFairValueGaps(candles) {
+    if (!Array.isArray(candles) || candles.length < 3) {
+      return [];
+    }
+    const result = [];
+    const maxLookahead = 160;
+    for (let i = 1; i < candles.length - 1; i += 1) {
+      const prev = candles[i - 1];
+      const curr = candles[i];
+      const next = candles[i + 1];
+      if (!prev || !curr || !next) {
+        continue;
+      }
+      if (
+        Number.isFinite(prev.high) &&
+        Number.isFinite(curr.low) &&
+        Number.isFinite(next.low) &&
+        prev.high < next.low &&
+        curr.low > prev.high
+      ) {
+        const gapTop = next.low;
+        const gapBottom = prev.high;
+        const gapSize = gapTop - gapBottom;
+        if (!Number.isFinite(gapSize) || gapSize <= 0) {
+          continue;
+        }
+        const refPrice = Number.isFinite(curr.close) ? Math.abs(curr.close) : Math.abs(curr.open || gapTop);
+        if (!Number.isFinite(refPrice) || refPrice === 0) {
+          continue;
+        }
+        const ratio = gapSize / refPrice;
+        if (ratio < 0.0003) {
+          continue;
+        }
+        const limit = Math.min(candles.length - 1, i + maxLookahead);
+        let endIndex = limit;
+        for (let j = i + 1; j <= limit; j += 1) {
+          if (Number.isFinite(candles[j].low) && candles[j].low <= gapBottom) {
+            endIndex = j;
+            break;
+          }
+        }
+        result.push({
+          type: 'bullish',
+          startIndex: Math.max(0, i - 1),
+          endIndex,
+          startTime: curr.time,
+          endTime: candles[endIndex]?.time ?? curr.time,
+          top: gapTop,
+          bottom: gapBottom,
+        });
+      } else if (
+        Number.isFinite(prev.low) &&
+        Number.isFinite(curr.high) &&
+        Number.isFinite(next.high) &&
+        prev.low > next.high &&
+        curr.high < prev.low
+      ) {
+        const gapTop = prev.low;
+        const gapBottom = next.high;
+        const gapSize = gapTop - gapBottom;
+        if (!Number.isFinite(gapSize) || gapSize <= 0) {
+          continue;
+        }
+        const refPrice = Number.isFinite(curr.close) ? Math.abs(curr.close) : Math.abs(curr.open || gapTop);
+        if (!Number.isFinite(refPrice) || refPrice === 0) {
+          continue;
+        }
+        const ratio = gapSize / refPrice;
+        if (ratio < 0.0003) {
+          continue;
+        }
+        const limit = Math.min(candles.length - 1, i + maxLookahead);
+        let endIndex = limit;
+        for (let j = i + 1; j <= limit; j += 1) {
+          if (Number.isFinite(candles[j].high) && candles[j].high >= gapTop) {
+            endIndex = j;
+            break;
+          }
+        }
+        result.push({
+          type: 'bearish',
+          startIndex: Math.max(0, i - 1),
+          endIndex,
+          startTime: curr.time,
+          endTime: candles[endIndex]?.time ?? curr.time,
+          top: gapTop,
+          bottom: gapBottom,
+        });
+      }
+    }
+    return result.slice(-40);
+  }
+
+  function detectOrderBlocks(candles) {
+    if (!Array.isArray(candles) || candles.length < 5) {
+      return [];
+    }
+    const result = [];
+    const lookback = 8;
+    const lookahead = 18;
+    for (let i = lookback; i < candles.length - 1; i += 1) {
+      const candle = candles[i];
+      if (!candle) {
+        continue;
+      }
+      const range = candle.high - candle.low;
+      if (!Number.isFinite(range) || range <= 0) {
+        continue;
+      }
+      const body = Math.abs(candle.close - candle.open);
+      if (!Number.isFinite(body) || body / range < 0.4) {
+        continue;
+      }
+      if (candle.close < candle.open) {
+        const windowStart = Math.max(0, i - lookback);
+        let prevHigh = candle.high;
+        for (let k = windowStart; k <= i; k += 1) {
+          prevHigh = Math.max(prevHigh, candles[k].high);
+        }
+        let breakoutIndex = null;
+        const limit = Math.min(candles.length - 1, i + lookahead);
+        for (let j = i + 1; j <= limit; j += 1) {
+          if (candles[j].close > prevHigh) {
+            breakoutIndex = j;
+            break;
+          }
+        }
+        if (breakoutIndex != null) {
+          let endIndex = limit;
+          for (let j = breakoutIndex; j <= limit; j += 1) {
+            if (candles[j].close < candle.close || candles[j].low < candle.low) {
+              endIndex = j;
+              break;
+            }
+          }
+          result.push({
+            type: 'bullish',
+            startIndex: i,
+            endIndex,
+            startTime: candle.time,
+            endTime: candles[endIndex]?.time ?? candle.time,
+            top: candle.open,
+            bottom: Math.min(candle.low, candle.close),
+          });
+        }
+      } else if (candle.close > candle.open) {
+        const windowStart = Math.max(0, i - lookback);
+        let prevLow = candle.low;
+        for (let k = windowStart; k <= i; k += 1) {
+          prevLow = Math.min(prevLow, candles[k].low);
+        }
+        let breakdownIndex = null;
+        const limit = Math.min(candles.length - 1, i + lookahead);
+        for (let j = i + 1; j <= limit; j += 1) {
+          if (candles[j].close < prevLow) {
+            breakdownIndex = j;
+            break;
+          }
+        }
+        if (breakdownIndex != null) {
+          let endIndex = limit;
+          for (let j = breakdownIndex; j <= limit; j += 1) {
+            if (candles[j].close > candle.close || candles[j].high > candle.high) {
+              endIndex = j;
+              break;
+            }
+          }
+          result.push({
+            type: 'bearish',
+            startIndex: i,
+            endIndex,
+            startTime: candle.time,
+            endTime: candles[endIndex]?.time ?? candle.time,
+            top: Math.max(candle.high, candle.close),
+            bottom: candle.open,
+          });
+        }
+      }
+    }
+    return result.slice(-30);
+  }
+
+  function renderOverlayPrimitives() {
+    if (!overlayState.chart || !overlayState.series || !overlayState.shapesRoot) {
+      return;
+    }
+    overlayState.shapesRoot.innerHTML = '';
+    if (!overlayState.candles.length) {
+      return;
+    }
+    const timeScale = overlayState.chart.timeScale();
+    const fvgs = (overlayState.fvgs || []).slice(-14);
+    const obs = (overlayState.obs || []).slice(-12);
+
+    fvgs.forEach((fvg) => {
+      if (!fvg) return;
+      const left = timeScale.timeToCoordinate(fvg.startTime);
+      const right = timeScale.timeToCoordinate(fvg.endTime);
+      const topCoord = overlayState.series.priceToCoordinate(fvg.top);
+      const bottomCoord = overlayState.series.priceToCoordinate(fvg.bottom);
+      if (
+        left == null ||
+        right == null ||
+        topCoord == null ||
+        bottomCoord == null ||
+        !Number.isFinite(left) ||
+        !Number.isFinite(right) ||
+        !Number.isFinite(topCoord) ||
+        !Number.isFinite(bottomCoord)
+      ) {
+        return;
+      }
+      const x = Math.min(left, right);
+      const y = Math.min(topCoord, bottomCoord);
+      const width = Math.max(6, Math.abs(right - left));
+      const height = Math.max(12, Math.abs(bottomCoord - topCoord));
+      const node = document.createElement('div');
+      node.className = `fvg-box ${fvg.type}`;
+      node.style.transform = `translate(${x}px, ${y}px)`;
+      node.style.width = `${width}px`;
+      node.style.height = `${height}px`;
+      node.style.zIndex = '1';
+      const bar = document.createElement('div');
+      bar.className = 'fvg-volume-bar';
+      const bull = document.createElement('span');
+      const bear = document.createElement('span');
+      const bullPct = Math.max(0, Math.min(100, Math.round(fvg.volume?.bullish ?? 0)));
+      const bearPct = Math.max(0, Math.min(100, Math.round(fvg.volume?.bearish ?? 0)));
+      const bullFlex = bullPct > 0 ? bullPct : 1;
+      const bearFlex = bearPct > 0 ? bearPct : 1;
+      bull.className = `bull${bullPct <= 0 ? ' empty' : ''}`;
+      bear.className = `bear${bearPct <= 0 ? ' empty' : ''}`;
+      bull.style.flex = String(bullFlex);
+      bear.style.flex = String(bearFlex);
+      bull.textContent = `${bullPct}%`;
+      bear.textContent = `${bearPct}%`;
+      bar.append(bull, bear);
+      node.append(bar);
+      overlayState.shapesRoot.append(node);
+    });
+
+    obs.forEach((ob) => {
+      if (!ob) return;
+      const left = timeScale.timeToCoordinate(ob.startTime);
+      const right = timeScale.timeToCoordinate(ob.endTime);
+      const topCoord = overlayState.series.priceToCoordinate(ob.top);
+      const bottomCoord = overlayState.series.priceToCoordinate(ob.bottom);
+      if (
+        left == null ||
+        right == null ||
+        topCoord == null ||
+        bottomCoord == null ||
+        !Number.isFinite(left) ||
+        !Number.isFinite(right) ||
+        !Number.isFinite(topCoord) ||
+        !Number.isFinite(bottomCoord)
+      ) {
+        return;
+      }
+      const x = Math.min(left, right);
+      const y = Math.min(topCoord, bottomCoord);
+      const width = Math.max(4, Math.abs(right - left));
+      const height = Math.max(10, Math.abs(bottomCoord - topCoord));
+      const node = document.createElement('div');
+      node.className = `ob-box ${ob.type}`;
+      node.style.transform = `translate(${x}px, ${y}px)`;
+      node.style.width = `${width}px`;
+      node.style.height = `${height}px`;
+      node.style.zIndex = '2';
+      const label = document.createElement('span');
+      label.className = 'ob-label';
+      label.textContent = ob.type === 'bullish' ? 'Bull OB' : 'Bear OB';
+      node.append(label);
+      overlayState.shapesRoot.append(node);
+    });
+  }
+
+  function updateOverlay(payload, candles) {
+    if (!overlayState.container) {
+      return;
+    }
+    if (!overlayState.chart) {
+      initOverlayChart();
+    }
+    const validCandles = Array.isArray(candles)
+      ? candles
+          .map((item) => ({
+            time: Math.floor(Number(item?.time) || 0),
+            open: Number(item?.open),
+            high: Number(item?.high),
+            low: Number(item?.low),
+            close: Number(item?.close),
+          }))
+          .filter((item) =>
+            Number.isFinite(item.time) &&
+            Number.isFinite(item.open) &&
+            Number.isFinite(item.high) &&
+            Number.isFinite(item.low) &&
+            Number.isFinite(item.close)
+          )
+          .sort((a, b) => a.time - b.time)
+      : [];
+
+    overlayState.candles = validCandles;
+    overlayState.bucketMs = timeframeToMs(payload?.timeframe);
+    overlayState.volumeBuckets = buildVolumeBuckets(payload);
+
+    if (overlayState.series) {
+      try {
+        overlayState.series.setData(validCandles);
+        if (validCandles.length) {
+          overlayState.chart.timeScale().fitContent();
+        }
+      } catch (error) {
+        console.warn('[LiqHeatmap] Failed to render overlay series:', error);
+      }
+    }
+
+    if (!validCandles.length) {
+      overlayState.fvgs = [];
+      overlayState.obs = [];
+      scheduleOverlayRender();
+      return;
+    }
+
+    const fvgs = detectFairValueGaps(validCandles).map((fvg) => ({
+      ...fvg,
+      volume: computeFvgVolume(fvg),
+    }));
+    overlayState.fvgs = fvgs;
+    overlayState.obs = detectOrderBlocks(validCandles);
+    scheduleOverlayRender();
   }
 
   function buildHeatmapOption(payload) {
@@ -287,11 +818,12 @@
     }
   }
 
-  function render(payload) {
+  function render(payload, candles) {
     if (!payload || !Array.isArray(payload.timestamps) || payload.timestamps.length === 0) {
       setEmptyVisible(true);
       updateTotals(payload);
       updateMeta(payload);
+      updateOverlay(payload || {}, []);
       return;
     }
     setEmptyVisible(false);
@@ -301,6 +833,45 @@
     }
     updateTotals(payload);
     updateMeta(payload);
+    updateOverlay(payload, candles);
+  }
+
+  async function fetchCandles(symbol, timeframe, limit, signal) {
+    if (!symbol || !timeframe) {
+      return [];
+    }
+    const safeLimit = Math.max(120, Math.min(1500, Number(limit) || 720));
+    const url = new URL('https://fapi.binance.com/fapi/v1/klines');
+    url.searchParams.set('symbol', String(symbol).toUpperCase());
+    url.searchParams.set('interval', timeframe);
+    url.searchParams.set('limit', String(safeLimit));
+    const response = await fetch(url.toString(), { signal });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    const data = await response.json();
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data
+      .map((row) => ({
+        time: Math.floor(Number(row?.[0]) / 1000),
+        open: Number(row?.[1]),
+        high: Number(row?.[2]),
+        low: Number(row?.[3]),
+        close: Number(row?.[4]),
+        volume: Number(row?.[5]),
+      }))
+      .filter((item, idx, arr) => {
+        if (!Number.isFinite(item.time) || !Number.isFinite(item.open) || !Number.isFinite(item.high) || !Number.isFinite(item.low) || !Number.isFinite(item.close)) {
+          return false;
+        }
+        if (idx > 0 && item.time === arr[idx - 1].time) {
+          return false;
+        }
+        return true;
+      })
+      .sort((a, b) => a.time - b.time);
   }
 
   async function loadSymbols() {
@@ -355,14 +926,22 @@
 
     try {
       setLoading(true);
-      const response = await fetch(`/api/liquidations?${params.toString()}`, {
+      const heatmapPromise = fetch(`/api/liquidations?${params.toString()}`, {
         signal: controller.signal,
+      }).then((response) => {
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}`);
+        }
+        return response.json();
       });
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}`);
-      }
-      const payload = await response.json();
-      render(payload);
+      const candlesPromise = fetchCandles(state.symbol, preset.tf, preset.limit + 20, controller.signal).catch((error) => {
+        if (error.name !== 'AbortError') {
+          console.warn('[LiqHeatmap] Candle fetch failed:', error);
+        }
+        return [];
+      });
+      const [payload, candles] = await Promise.all([heatmapPromise, candlesPromise]);
+      render(payload, candles);
     } catch (error) {
       if (error.name === 'AbortError') {
         return;
@@ -420,5 +999,10 @@
 
   window.addEventListener('resize', () => {
     chart.resize();
+    if (overlayState.chart && overlayState.container) {
+      const rect = overlayState.container.getBoundingClientRect();
+      overlayState.chart.resize(rect.width, rect.height);
+      scheduleOverlayRender();
+    }
   });
 })();


### PR DESCRIPTION
## Summary
- integrate Lightweight Charts overlay with Binance candles to detect and draw fair value gaps, including bullish/bearish volume ratio bars inside each box
- surface bullish and bearish order blocks on the liquidation heatmap while keeping the existing neon aesthetic and crediting the original Volumatic indicator
- add supporting styles and Lightweight Charts dependency to the liquidation heatmap page

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e030d699c0832f9c7b0ab10afb307e